### PR TITLE
fix: use dynamic datetime overlay based on video playback position

### DIFF
--- a/src/components/VideoExporter.tsx
+++ b/src/components/VideoExporter.tsx
@@ -753,7 +753,10 @@ export function VideoExporter({
           drawTelemetry(ctx, seiData, width, height, telemetryIcons);
         }
         if (showDateTime) {
-          drawDateTime(ctx, width, height, moment.date, moment.time, showTelemetry);
+          const realTime = new Date(moment.timestamp.getTime() + localTime * 1000);
+          const dynamicDate = realTime.toISOString().split('T')[0];
+          const dynamicTime = realTime.toTimeString().split(' ')[0];
+          drawDateTime(ctx, width, height, dynamicDate, dynamicTime, showTelemetry);
         }
         if (showMap) {
           await drawMiniMap(ctx, seiData, width, height);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -762,7 +762,12 @@ export function VideoPlayer({
             showTelemetry ? 'top-[95px]' : 'top-3'
           }`}>
             <div className="px-2 py-1 rounded-md bg-black/50 backdrop-blur-sm text-white/90 text-xs font-medium">
-              {currentMoment.date} &nbsp; {currentMoment.time}
+              {(() => {
+                const realTime = new Date(currentMoment.timestamp.getTime() + localTime * 1000);
+                const date = realTime.toISOString().split('T')[0];
+                const time = realTime.toTimeString().split(' ')[0];
+                return <>{date} &nbsp; {time}</>;
+              })()}
             </div>
           </div>
         )}


### PR DESCRIPTION
The datetime overlay was showing the static clip start time instead of updating as the video plays. Now computes real time by adding playback offset to the clip's base timestamp, for both preview and export.