### PR TITLE
feat: add visible speed unit toggle (MPH/KMH) in toolbar

### DIFF
--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1041,6 +1041,14 @@ export function VideoPlayer({
                 <IconClock size={16} />
               </button>
             </Tooltip>
+            <Tooltip content={`Speed: ${speedUnit === 'mph' ? 'mph' : 'km/h'} (click to switch)`} position="top">
+              <button
+                onClick={() => setSpeedUnit(prev => prev === 'mph' ? 'kmh' : 'mph')}
+                className="px-1.5 h-[28px] flex items-center rounded transition-all bg-gray-700 text-gray-300 hover:bg-gray-600 text-[10px] font-bold leading-none"
+              >
+                {speedUnit === 'mph' ? 'MPH' : 'KMH'}
+              </button>
+            </Tooltip>
 
             {/* Divider */}
             <div className="w-px h-4 bg-gray-600 mx-1" />


### PR DESCRIPTION
Adds an explicit MPH/KMH switcher button next to the datetime toggle so users can easily discover and change the speed unit without needing to click on the telemetry overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a speed unit toggle button to the video player controls. Users can now easily switch between MPH and KMH measurements with a single click. The button clearly displays the current unit and includes a tooltip to guide usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->