### PR TITLE
feat: add event.json support with timeline event marker

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,11 +30,11 @@ export default function Home() {
     });
 
     try {
-      // Process files into moments
-      const moments = await processFilesToMoments(newFiles, setProcessingProgress);
+      // Process files into moments (also parses event.json files)
+      const { moments, events } = await processFilesToMoments(newFiles, setProcessingProgress);
 
-      // Detect sequences from moments
-      const detectedSequences = detectSequences(moments);
+      // Detect sequences from moments, matching events to sequences
+      const detectedSequences = detectSequences(moments, events);
 
       // Update state
       setSequences(detectedSequences);

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -35,7 +35,8 @@ export function DropZone({ onFilesAdded, hasVideos }: DropZoneProps) {
           const file = await new Promise<File>((resolve, reject) => {
             fileEntry.file(resolve, reject);
           });
-          if (file.name.toLowerCase().endsWith('.mp4')) {
+          const name = file.name.toLowerCase();
+          if (name.endsWith('.mp4') || name === 'event.json') {
             files.push(file);
           }
         } else if (entry.isDirectory) {
@@ -61,9 +62,10 @@ export function DropZone({ onFilesAdded, hasVideos }: DropZoneProps) {
         await Promise.all(entries.map(processEntry));
       } else {
         // Fallback for browsers without webkitGetAsEntry
-        const droppedFiles = Array.from(e.dataTransfer.files).filter((f) =>
-          f.name.toLowerCase().endsWith('.mp4')
-        );
+        const droppedFiles = Array.from(e.dataTransfer.files).filter((f) => {
+          const name = f.name.toLowerCase();
+          return name.endsWith('.mp4') || name === 'event.json';
+        });
         files.push(...droppedFiles);
       }
 
@@ -76,9 +78,10 @@ export function DropZone({ onFilesAdded, hasVideos }: DropZoneProps) {
 
   const handleFileInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const files = Array.from(e.target.files || []).filter((f) =>
-        f.name.toLowerCase().endsWith('.mp4')
-      );
+      const files = Array.from(e.target.files || []).filter((f) => {
+        const name = f.name.toLowerCase();
+        return name.endsWith('.mp4') || name === 'event.json';
+      });
       if (files.length > 0) {
         onFilesAdded(files);
       }
@@ -100,7 +103,7 @@ export function DropZone({ onFilesAdded, hasVideos }: DropZoneProps) {
           <span className="text-sm">Drop more videos or click to add</span>
           <input
             type="file"
-            accept="video/mp4"
+            accept="video/mp4,application/json"
             multiple
             onChange={handleFileInput}
             className="hidden"
@@ -183,7 +186,7 @@ export function DropZone({ onFilesAdded, hasVideos }: DropZoneProps) {
           <span>Browse Files</span>
           <input
             type="file"
-            accept="video/mp4"
+            accept="video/mp4,application/json"
             multiple
             onChange={handleFileInput}
             className="hidden"

--- a/src/components/TelemetryTimeline.tsx
+++ b/src/components/TelemetryTimeline.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useRef, useCallback, useEffect, useState } from 'react';
 import { SeiWithFrameIndex } from '@/lib/dashcam-mp4';
-import { TrimPoints, CameraSegment, ANGLE_COLORS, ANGLE_LABELS } from '@/types/video';
+import { TrimPoints, CameraSegment, ANGLE_COLORS, ANGLE_LABELS, TeslaEvent } from '@/types/video';
 import { Tooltip } from './Tooltip';
 
 interface TelemetryTimelineProps {
@@ -13,6 +13,8 @@ interface TelemetryTimelineProps {
   onSeek: (time: number) => void;
   onDraggingChange?: (isDragging: boolean) => void;
   clipBoundaries?: number[];  // Offset times where each clip starts (for multi-clip sequences)
+  event?: TeslaEvent;
+  sequenceStartTime?: Date;
   // Edit mode props
   isEditMode?: boolean;
   isTrimming?: boolean;  // When true, show full timeline for trimming
@@ -47,6 +49,8 @@ export function TelemetryTimeline({
   onSeek,
   onDraggingChange,
   clipBoundaries = [],
+  event,
+  sequenceStartTime,
   isEditMode = false,
   isTrimming = false,
   onTrimmingChange,
@@ -174,6 +178,16 @@ export function TelemetryTimeline({
   const [draggingSegmentBoundary, setDraggingSegmentBoundary] = useState<number | null>(null);
   const [draggingAngle, setDraggingAngle] = useState<string | null>(null); // For drag-drop from palette
   const [dragPosition, setDragPosition] = useState<{ x: number; y: number } | null>(null); // Mouse position for drag ghost
+
+  // Calculate event position in absolute time
+  const eventAbsoluteTime = useMemo(() => {
+    if (!event || !sequenceStartTime) return null;
+    const offsetSeconds = (event.timestamp.getTime() - sequenceStartTime.getTime()) / 1000;
+    if (offsetSeconds < 0 || offsetSeconds > duration) return null;
+    return offsetSeconds;
+  }, [event, sequenceStartTime, duration]);
+
+  const [showEventTooltip, setShowEventTooltip] = useState(false);
 
   // Notify parent when dragging state changes
   useEffect(() => {
@@ -462,7 +476,7 @@ export function TelemetryTimeline({
     };
   }, [draggingAngle]);
 
-  if (allSeiMessages.length === 0 || duration <= 0) {
+  if (duration <= 0) {
     return null;
   }
 
@@ -557,6 +571,12 @@ export function TelemetryTimeline({
           )}
 
           {/* Track legend */}
+          {event && (
+            <div className="flex items-center gap-1">
+              <div className="w-2 h-2 rotate-45 bg-orange-500" />
+              <span className="text-[10px] text-orange-400 font-medium">{event.reasonLabel}</span>
+            </div>
+          )}
           {tracks.map((track) => (
             <div key={track.id} className="flex items-center gap-1">
               <div className="w-2 h-2 rounded-full" style={{ backgroundColor: track.color }} />
@@ -576,7 +596,7 @@ export function TelemetryTimeline({
       {/* Main Timeline */}
       <div
         ref={timelineRef}
-        className={`relative select-none ${isDragging || draggingTrimHandle ? 'cursor-grabbing' : 'cursor-pointer'}`}
+        className={`relative select-none min-h-[60px] rounded bg-gray-700/30 ${isDragging || draggingTrimHandle ? 'cursor-grabbing' : 'cursor-pointer'}`}
         onMouseDown={handleMouseDown}
         onTouchStart={handleTouchStart}
       >
@@ -595,6 +615,40 @@ export function TelemetryTimeline({
             />
           );
         })}
+
+        {/* Event marker */}
+        {eventAbsoluteTime !== null && eventAbsoluteTime >= viewStart && eventAbsoluteTime <= viewEnd && (
+          <div
+            className="absolute top-0 bottom-0 z-[6] group"
+            style={{ left: `${timeToPosition(eventAbsoluteTime)}%` }}
+            onMouseEnter={() => setShowEventTooltip(true)}
+            onMouseLeave={() => setShowEventTooltip(false)}
+          >
+            {/* Vertical line */}
+            <div className="absolute top-0 bottom-0 w-0.5 bg-orange-500 -translate-x-1/2 pointer-events-none" />
+            {/* Diamond marker */}
+            <div className="absolute -top-2 left-1/2 -translate-x-1/2 w-4 h-4 pointer-events-auto cursor-default">
+              <div className="w-3 h-3 bg-orange-500 rotate-45 transform mx-auto border border-orange-300 shadow-lg shadow-orange-500/30" />
+            </div>
+            {/* Tooltip */}
+            {showEventTooltip && event && (
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 pointer-events-none z-[20]">
+                <div className="bg-gray-900 border border-orange-500/40 rounded-lg px-3 py-2 text-xs shadow-xl whitespace-nowrap">
+                  <div className="font-semibold text-orange-400">{event.reasonLabel}</div>
+                  {(event.city || event.street) && (
+                    <div className="text-gray-400 mt-0.5">
+                      {[event.street, event.city].filter(Boolean).join(', ')}
+                    </div>
+                  )}
+                  <div className="text-gray-500 mt-0.5 text-[10px]">
+                    {event.timestamp.toLocaleTimeString()}
+                  </div>
+                </div>
+                <div className="absolute top-full left-1/2 -translate-x-1/2 w-2 h-2 bg-gray-900 border-r border-b border-orange-500/40 rotate-45 -mt-1" />
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Time interval lines */}
         {timeMarkers.slice(1, -1).map((time) => (

--- a/src/components/VideoExporter.tsx
+++ b/src/components/VideoExporter.tsx
@@ -794,7 +794,7 @@ export function VideoExporter({
         const { clipIdx, localTime } = clipInfo;
         const moment = sequence.moments[clipIdx];
 
-        setStatus(`Processing: ${formatDuration(absoluteTime)} / ${formatDuration(exportEnd)}`);
+        setStatus(`Processing: ${formatDuration(absoluteTime - exportStart)} / ${formatDuration(exportDuration)}`);
 
         if (layout === 'triple') {
           // Load and seek all 3 angles

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1217,7 +1217,7 @@ export function VideoPlayer({
       </div>
 
         {/* Telemetry Timeline */}
-        {allSeiMessages.length > 0 && (
+        {totalDuration > 0 && (
           <TelemetryTimeline
             allSeiMessages={allSeiMessages}
             fps={fps}
@@ -1226,6 +1226,8 @@ export function VideoPlayer({
             onSeek={handleTimelineSeek}
             onDraggingChange={setIsTimelineDragging}
             clipBoundaries={sequence.momentOffsets}
+            event={sequence.event}
+            sequenceStartTime={sequence.startTime}
             isEditMode={isEditMode}
             isTrimming={isTrimming}
             onTrimmingChange={setIsTrimming}

--- a/src/lib/sequence-detector.ts
+++ b/src/lib/sequence-detector.ts
@@ -11,10 +11,12 @@ import {
   VideoSequence,
   CameraVideo,
   ProcessingProgress,
+  TeslaEvent,
   parseAngle,
   parseTimestamp,
   formatDuration,
   formatFileSize,
+  getReasonLabel,
   ANGLE_LABELS,
   ANGLE_ORDER,
 } from '@/types/video';
@@ -43,24 +45,69 @@ async function getVideoDuration(file: File): Promise<number> {
   });
 }
 
+/** Parse an event.json file into a TeslaEvent */
+async function parseEventJson(file: File): Promise<TeslaEvent | null> {
+  try {
+    const text = await file.text();
+    const data = JSON.parse(text);
+    if (!data.timestamp || !data.reason) return null;
+
+    // Parse timestamp: "2026-02-07T17:36:02" (local time, no timezone)
+    const ts = new Date(data.timestamp);
+    if (isNaN(ts.getTime())) return null;
+
+    return {
+      timestamp: ts,
+      city: data.city || undefined,
+      street: data.street || undefined,
+      est_lat: data.est_lat ? parseFloat(data.est_lat) : undefined,
+      est_lon: data.est_lon ? parseFloat(data.est_lon) : undefined,
+      reason: data.reason,
+      reasonLabel: getReasonLabel(data.reason),
+      camera: data.camera || undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Process raw video files into VideoMoments grouped by timestamp
+ * Process raw video files into VideoMoments grouped by timestamp.
+ * Also parses any event.json files found alongside the videos.
  */
 export async function processFilesToMoments(
   files: File[],
   onProgress?: (progress: ProcessingProgress) => void
-): Promise<VideoMoment[]> {
-  // Group files by timestamp
+): Promise<{ moments: VideoMoment[]; events: TeslaEvent[] }> {
+  // Separate JSON files from MP4 files
+  const videoFiles: File[] = [];
+  const jsonFiles: File[] = [];
+  for (const file of files) {
+    if (file.name.toLowerCase() === 'event.json') {
+      jsonFiles.push(file);
+    } else {
+      videoFiles.push(file);
+    }
+  }
+
+  // Parse event.json files
+  const events: TeslaEvent[] = [];
+  for (const jsonFile of jsonFiles) {
+    const event = await parseEventJson(jsonFile);
+    if (event) events.push(event);
+  }
+
+  // Group video files by timestamp
   const groups: Record<string, { file: File; angle: string | null; timestamp: Date | null }[]> = {};
 
   onProgress?.({
     stage: 'scanning',
     current: 0,
-    total: files.length,
+    total: videoFiles.length,
     message: 'Scanning files...',
   });
 
-  for (const file of files) {
+  for (const file of videoFiles) {
     const timestamp = parseTimestamp(file.name);
     const key = timestamp
       ? timestamp.toISOString()
@@ -91,7 +138,7 @@ export async function processFilesToMoments(
         onProgress?.({
           stage: 'metadata',
           current: processedCount,
-          total: files.length,
+          total: videoFiles.length,
           message: `Processing ${file.name}...`,
         });
 
@@ -138,12 +185,12 @@ export async function processFilesToMoments(
 
   onProgress?.({
     stage: 'ready',
-    current: files.length,
-    total: files.length,
+    current: videoFiles.length,
+    total: videoFiles.length,
     message: 'Ready',
   });
 
-  return moments;
+  return { moments, events };
 }
 
 /**
@@ -155,7 +202,7 @@ export async function processFilesToMoments(
  * - Clip 3: 10:32:00 (60s duration) ← 0s gap after Clip 2 ends, merge
  * - Clip 4: 10:45:00 (60s duration) ← 12min gap, new sequence
  */
-export function detectSequences(moments: VideoMoment[]): VideoSequence[] {
+export function detectSequences(moments: VideoMoment[], events: TeslaEvent[] = []): VideoSequence[] {
   if (moments.length === 0) return [];
 
   const sequences: VideoSequence[] = [];
@@ -183,6 +230,19 @@ export function detectSequences(moments: VideoMoment[]): VideoSequence[] {
   // Don't forget the last sequence
   if (currentSequenceMoments.length > 0) {
     sequences.push(createSequence(currentSequenceMoments));
+  }
+
+  // Match events to sequences by timestamp overlap
+  for (const event of events) {
+    const eventTime = event.timestamp.getTime();
+    for (const seq of sequences) {
+      const seqStart = seq.startTime.getTime();
+      const seqEnd = seq.endTime.getTime();
+      if (eventTime >= seqStart && eventTime <= seqEnd) {
+        seq.event = event;
+        break;
+      }
+    }
   }
 
   return sequences;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -51,6 +51,44 @@ export interface VideoSequence {
 
   // Playback mapping: cumulative durations for seeking
   momentOffsets: number[];       // Start time offset for each moment
+
+  // Optional event data from event.json
+  event?: TeslaEvent;
+}
+
+/** Tesla event data from event.json */
+export interface TeslaEvent {
+  timestamp: Date;
+  city?: string;
+  street?: string;
+  est_lat?: number;
+  est_lon?: number;
+  reason: string;
+  reasonLabel: string;
+  camera?: string;
+}
+
+/** Human-readable labels for Tesla event reasons */
+export const REASON_LABELS: Record<string, string> = {
+  user_interaction_dashcam_multifunction_selected: 'Manual Save',
+  user_interaction_dashcam_icon_tapped: 'Manual Save',
+  user_interaction_honk: 'Honk Save',
+  sentry_aware_object_detection: 'Sentry: Object Detected',
+  sentry_aware_accel: 'Sentry: Acceleration',
+  sentry_aware_intrusion: 'Sentry: Intrusion',
+  sentry_aware_proximity: 'Sentry: Proximity',
+  sentry_ion: 'Sentry Mode',
+  sentry_ioff: 'Sentry Off',
+  dashcam_clip_request: 'Dashcam Clip',
+  emergency_braking: 'Emergency Braking',
+  forward_collision_warning: 'Forward Collision Warning',
+  auto_emergency_braking: 'Auto Emergency Braking',
+  ap_forward_collision: 'Autopilot: Forward Collision',
+};
+
+/** Get human-readable label for an event reason */
+export function getReasonLabel(reason: string): string {
+  return REASON_LABELS[reason] || reason.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
 /** Angle constants and utilities */


### PR DESCRIPTION
Closes #14

Parse Tesla's event.json files dropped alongside MP4 clips to display event trigger markers on the telemetry timeline. Adds TeslaEvent type with human-readable reason labels, accepts JSON files in DropZone, matches events to sequences by timestamp overlap, and renders an orange diamond marker with hover tooltip showing reason and location.

Also fixes:
- Timeline now always renders (even without SEI telemetry data)
- Export progress shows trimmed-relative time instead of absolute time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for uploading event data files alongside videos
  * Event markers now display on the telemetry timeline with hover tooltips
  * Events are automatically matched to corresponding video sequences
  * Event details (location, reason, camera) visible during playback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->