### PR TITLE
fix: show blue steering wheel when Autopilot is active

### DIFF
--- a/src/components/TelemetryCard.tsx
+++ b/src/components/TelemetryCard.tsx
@@ -101,7 +101,7 @@ export function TelemetryCard({
 
         {/* Column 2: Steering + Accelerator */}
         <div className="telemetry-column">
-          <div className="telemetry-circle telemetry-steering">
+          <div className={`telemetry-circle telemetry-steering ${isAutopilotActive ? 'autopilot' : ''}`}>
             <Image
               src="/wheel.svg"
               alt="Steering"
@@ -164,9 +164,17 @@ export function TelemetryCard({
           background: #ff4444;
         }
 
+        .telemetry-steering.autopilot {
+          background: #006deb;
+        }
+
         .telemetry-steering :global(.wheel-icon) {
           filter: brightness(0.5);
           transition: transform 0.1s ease-out;
+        }
+
+        .telemetry-steering.autopilot :global(.wheel-icon) {
+          filter: brightness(0) invert(1);
         }
 
         .telemetry-accelerator {

--- a/src/components/VideoExporter.tsx
+++ b/src/components/VideoExporter.tsx
@@ -308,8 +308,9 @@ export function VideoExporter({
     posX += blinkerWidth + gap;
 
     // === Right Column: Steering + Accelerator ===
-    // Steering circle with wheel icon
-    ctx.fillStyle = '#a4a4a4';
+    // Steering circle with wheel icon (blue when autopilot active)
+    const isAutopilotActive = (seiData.autopilot_state ?? 0) > 0;
+    ctx.fillStyle = isAutopilotActive ? '#006deb' : '#a4a4a4';
     ctx.beginPath();
     ctx.arc(posX + circleSize / 2, topCircleY, circleSize / 2, 0, Math.PI * 2);
     ctx.fill();
@@ -375,7 +376,6 @@ export function VideoExporter({
     }
 
     // === Autopilot label ===
-    const isAutopilotActive = (seiData.autopilot_state ?? 0) > 0;
     if (isAutopilotActive) {
       const autopilotLabels: Record<number, string> = { 1: 'Self Driving', 2: 'Autosteer', 3: 'TACC' };
       const label = autopilotLabels[seiData.autopilot_state ?? 0] || '';


### PR DESCRIPTION
Closes #15

The steering wheel circle now turns blue when autopilot_state > 0, matching Tesla's own visual indicator. Applied to both the live telemetry overlay and video export renderer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Steering indicator styling updated to reflect autopilot status across the interface
  * Autopilot-active state now displays with blue coloring for improved visual feedback
  * Enhanced wheel icon appearance for better visibility during autopilot operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->