### PR TITLE
feat: add customizable camera layout configuration

### DIFF
--- a/src/components/LayoutConfigPopover.tsx
+++ b/src/components/LayoutConfigPopover.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useEffect, useCallback } from 'react';
+import { LayoutCameraConfig, DEFAULT_LAYOUT_CONFIG, ANGLE_LABELS } from '@/types/video';
+import { IconRefresh, IconX } from '@tabler/icons-react';
+
+type LayoutType = 'pip' | 'triple' | 'all';
+
+interface LayoutConfigPopoverProps {
+  layout: LayoutType;
+  config: LayoutCameraConfig;
+  onChange: (config: LayoutCameraConfig) => void;
+  onClose: () => void;
+}
+
+const ALL_ANGLES = ['front', 'back', 'left_repeater', 'right_repeater', 'left_pillar', 'right_pillar'];
+
+const PIP_OPTIONS = ['none', ...ALL_ANGLES, 'map'];
+const PIP_LABELS: Record<string, string> = {
+  ...ANGLE_LABELS,
+  none: 'None',
+  map: 'Map',
+};
+
+function CameraSelect({
+  value,
+  onChange,
+  label,
+  options,
+  labels,
+}: {
+  value: string;
+  onChange: (angle: string) => void;
+  label: string;
+  options?: string[];
+  labels?: Record<string, string>;
+}) {
+  const opts = options || ALL_ANGLES;
+  const lbls = labels || ANGLE_LABELS;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <span className="text-[9px] text-gray-500 uppercase tracking-wide">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="bg-gray-700 text-gray-200 text-xs rounded px-1.5 py-1 border border-gray-600 hover:border-gray-500 focus:border-blue-500 focus:outline-none cursor-pointer w-[80px] text-center appearance-none"
+      >
+        {opts.map((angle) => (
+          <option key={angle} value={angle}>
+            {lbls[angle] || angle}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function LayoutConfigPopover({
+  layout,
+  config,
+  onChange,
+  onClose,
+}: LayoutConfigPopoverProps) {
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [onClose]);
+
+  const handleReset = useCallback(() => {
+    onChange({ ...DEFAULT_LAYOUT_CONFIG });
+  }, [onChange]);
+
+  // PiP config — screen simulation
+  // corners: [bottom-left, bottom-center, bottom-right, top-left, top-right]
+  const renderPipConfig = () => {
+    const corners = config.pip.corners;
+
+    const update = (index: number, angle: string) => {
+      const c = [...corners] as [string, string, string, string, string];
+      c[index] = angle;
+      onChange({ ...config, pip: { corners: c } });
+    };
+
+    return (
+      <div className="space-y-2">
+        <div className="text-[10px] text-gray-400 text-center">Corner cameras around main view</div>
+        {/* Screen simulation */}
+        <div className="relative bg-gray-900 rounded-lg border border-gray-600 aspect-video mx-auto max-w-[320px]">
+          {/* Main label */}
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-[10px] text-gray-600">Main Camera</span>
+          </div>
+          {/* Top row */}
+          <div className="absolute top-1.5 left-1.5 right-1.5 flex justify-between">
+            <CameraSelect value={corners[3]} onChange={(a) => update(3, a)} label="" options={PIP_OPTIONS} labels={PIP_LABELS} />
+            <CameraSelect value={corners[4]} onChange={(a) => update(4, a)} label="" options={PIP_OPTIONS} labels={PIP_LABELS} />
+          </div>
+          {/* Bottom row */}
+          <div className="absolute bottom-1.5 left-1.5 right-1.5 flex justify-between items-end">
+            <CameraSelect value={corners[0]} onChange={(a) => update(0, a)} label="" options={PIP_OPTIONS} labels={PIP_LABELS} />
+            <CameraSelect value={corners[1]} onChange={(a) => update(1, a)} label="" options={PIP_OPTIONS} labels={PIP_LABELS} />
+            <CameraSelect value={corners[2]} onChange={(a) => update(2, a)} label="" options={PIP_OPTIONS} labels={PIP_LABELS} />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // Triple config — screen simulation
+  const renderTripleConfig = () => {
+    const cameras = config.triple.cameras;
+
+    const updateCamera = (index: number, angle: string) => {
+      const newCameras = [...cameras] as [string, string, string];
+      newCameras[index] = angle;
+      onChange({ ...config, triple: { cameras: newCameras } });
+    };
+
+    return (
+      <div className="space-y-2">
+        <div className="text-[10px] text-gray-400 text-center">Three cameras side by side</div>
+        <div className="relative bg-gray-900 rounded-lg border border-gray-600 aspect-video mx-auto max-w-[320px]">
+          <div className="absolute inset-0 flex items-end justify-center gap-2 p-2">
+            <CameraSelect value={cameras[0]} onChange={(a) => updateCamera(0, a)} label="Left" />
+            <CameraSelect value={cameras[1]} onChange={(a) => updateCamera(1, a)} label="Center" />
+            <CameraSelect value={cameras[2]} onChange={(a) => updateCamera(2, a)} label="Right" />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // All 6 config — screen simulation
+  const renderAllConfig = () => {
+    const { topRow, bottomRow } = config.all;
+
+    const updateTop = (index: number, angle: string) => {
+      const newRow = [...topRow] as [string, string, string];
+      newRow[index] = angle;
+      onChange({ ...config, all: { topRow: newRow, bottomRow: config.all.bottomRow } });
+    };
+
+    const updateBottom = (index: number, angle: string) => {
+      const newRow = [...bottomRow] as [string, string, string];
+      newRow[index] = angle;
+      onChange({ ...config, all: { topRow: config.all.topRow, bottomRow: newRow } });
+    };
+
+    return (
+      <div className="space-y-2">
+        <div className="text-[10px] text-gray-400 text-center">Two rows of three cameras</div>
+        <div className="relative bg-gray-900 rounded-lg border border-gray-600 aspect-video mx-auto max-w-[320px]">
+          <div className="absolute inset-0 flex flex-col justify-center gap-2 p-2">
+            <div className="flex justify-center gap-2">
+              <CameraSelect value={topRow[0]} onChange={(a) => updateTop(0, a)} label="Top L" />
+              <CameraSelect value={topRow[1]} onChange={(a) => updateTop(1, a)} label="Top C" />
+              <CameraSelect value={topRow[2]} onChange={(a) => updateTop(2, a)} label="Top R" />
+            </div>
+            <div className="flex justify-center gap-2">
+              <CameraSelect value={bottomRow[0]} onChange={(a) => updateBottom(0, a)} label="Bot L" />
+              <CameraSelect value={bottomRow[1]} onChange={(a) => updateBottom(1, a)} label="Bot C" />
+              <CameraSelect value={bottomRow[2]} onChange={(a) => updateBottom(2, a)} label="Bot R" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const titles: Record<LayoutType, string> = {
+    pip: 'PiP Layout',
+    triple: 'Triple Layout',
+    all: 'All 6 Layout',
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div
+        className="bg-gray-800 border border-gray-600 rounded-xl shadow-2xl p-4 min-w-[340px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h4 className="text-sm font-semibold text-gray-200">{titles[layout]}</h4>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleReset}
+              className="flex items-center gap-1 text-[10px] text-gray-400 hover:text-gray-200 transition-colors"
+            >
+              <IconRefresh size={10} />
+              Reset
+            </button>
+            <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">
+              <IconX size={14} />
+            </button>
+          </div>
+        </div>
+
+        {layout === 'pip' && renderPipConfig()}
+        {layout === 'triple' && renderTripleConfig()}
+        {layout === 'all' && renderAllConfig()}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoExporter.tsx
+++ b/src/components/VideoExporter.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { IconDownload, IconPlayerStop, IconLoader2, IconCheck } from '@tabler/icons-react';
 import { SeiData, SeiWithFrameIndex } from '@/lib/dashcam-mp4';
 import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
-import { VideoSequence, TrimPoints, CameraSegment, formatDuration } from '@/types/video';
+import { VideoSequence, TrimPoints, CameraSegment, formatDuration, LayoutCameraConfig, DEFAULT_LAYOUT_CONFIG } from '@/types/video';
 import { Tooltip } from './Tooltip';
 
 type LayoutType = 'single' | 'pip' | 'triple' | 'all';
@@ -22,6 +22,7 @@ interface VideoExporterProps {
   showDateTime?: boolean;
   showMap?: boolean;
   layout?: LayoutType;
+  layoutConfig?: LayoutCameraConfig;
 }
 
 // Map tile cache
@@ -108,6 +109,7 @@ export function VideoExporter({
   showDateTime = true,
   showMap = true,
   layout = 'single',
+  layoutConfig = DEFAULT_LAYOUT_CONFIG,
 }: VideoExporterProps) {
   const [isExporting, setIsExporting] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
@@ -453,16 +455,16 @@ export function VideoExporter({
     seiData: SeiData | null,
     width: number,
     height: number,
-    position: 'top-right' | 'bottom-right' = 'bottom-right'
+    position: 'top-right' | 'bottom-right' | { x: number; y: number; size: number } = 'bottom-right'
   ) => {
     if (!seiData?.latitude_deg || !seiData?.longitude_deg) return;
     if (seiData.latitude_deg === 0 && seiData.longitude_deg === 0) return;
 
     const scale = Math.min(width / 1280, height / 720);
-    const mapSize = 160 * scale;
+    const mapSize = typeof position === 'object' ? position.size : 160 * scale;
     const padding = 12 * scale;
-    const x = width - mapSize - padding;
-    const y = position === 'top-right' ? padding : height - mapSize - padding;
+    const x = typeof position === 'object' ? position.x : width - mapSize - padding;
+    const y = typeof position === 'object' ? position.y : position === 'top-right' ? padding : height - mapSize - padding;
 
     const lat = seiData.latitude_deg;
     const lng = seiData.longitude_deg;
@@ -612,18 +614,18 @@ export function VideoExporter({
 
       const maxDimension = 1920;
 
-      // Determine export layout angles
-      const tripleAngles = ['left_pillar', 'front', 'right_pillar'];
-      const pipAngles = ['left_repeater', 'right_repeater', 'back'].filter(
-        a => a !== selectedAngle
+      // Determine export layout angles from config
+      const tripleAngles = [...layoutConfig.triple.cameras];
+      const pipAngles = layoutConfig.pip.corners.filter(
+        a => a !== selectedAngle && a !== 'none' && a !== 'map'
       );
 
       let width: number;
       let height: number;
 
       if (layout === 'triple') {
-        // Load a pillar video to get its dimensions
-        const pillarVideo = sequence.moments[0].videos.find(v => v.angle === 'left_pillar');
+        // Load a side video to get its dimensions
+        const pillarVideo = sequence.moments[0].videos.find(v => v.angle === tripleAngles[0]);
         let pillarW = srcWidth;
         let pillarH = srcHeight;
         if (pillarVideo) {
@@ -763,7 +765,7 @@ export function VideoExporter({
 
       // Prepare extra video elements for multi-angle layouts
       const layoutAngles = layout === 'triple' ? tripleAngles
-        : layout === 'pip' ? pipAngles.slice(0, 3)
+        : layout === 'pip' ? pipAngles
         : [];
 
       for (const angle of layoutAngles) {
@@ -841,8 +843,8 @@ export function VideoExporter({
           }
           await seekVideo(localTime);
 
-          // Load and seek PiP angles
-          for (const angle of pipAngles.slice(0, 3)) {
+          // Load and seek PiP camera angles
+          for (const angle of pipAngles) {
             const ev = extraVideos[angle];
             if (!ev) continue;
             const video = moment.videos.find(v => v.angle === angle);
@@ -858,49 +860,75 @@ export function VideoExporter({
           // Draw main video
           ctx.drawImage(tempVideo, 0, 0, width, height);
 
-          // Draw PiP windows (bottom corners + optional top-left)
+          // Draw PiP corners matching the 5-position layout config
+          // corners: [bottom-left, bottom-center, bottom-right, top-left, top-right]
+          const allCorners = layoutConfig.pip.corners;
           const pipW = Math.floor(width * 0.18);
           const pipMargin = Math.floor(width * 0.02);
-          const activePips = pipAngles.slice(0, 3).filter(a => moment.videos.some(v => v.angle === a));
 
-          // Bottom-left
-          if (activePips[0] && extraVideos[activePips[0]]) {
-            const ev = extraVideos[activePips[0]];
+          const drawPipAt = (angle: string, px: number, py: number) => {
+            const ev = extraVideos[angle];
+            if (!ev || !moment.videos.some(v => v.angle === angle)) return;
             const srcW = ev.el.videoWidth || 1;
             const srcH = ev.el.videoHeight || 1;
             const pipH = Math.floor(pipW * (srcH / srcW));
-            const px = pipMargin;
-            const py = height - pipH - pipMargin;
+            ctx.drawImage(ev.el, px, py, pipW, pipH);
             ctx.strokeStyle = 'rgba(255,255,255,0.2)';
             ctx.lineWidth = 1;
-            ctx.drawImage(ev.el, px, py, pipW, pipH);
             ctx.strokeRect(px, py, pipW, pipH);
+          };
+
+          // Compute pip height for positioning (use first available pip video)
+          let defaultPipH = Math.floor(pipW * 0.75); // fallback 4:3
+          for (const angle of pipAngles) {
+            const ev = extraVideos[angle];
+            if (ev?.el.videoWidth) {
+              defaultPipH = Math.floor(pipW * (ev.el.videoHeight / ev.el.videoWidth));
+              break;
+            }
           }
-          // Bottom-right
-          if (activePips[1] && extraVideos[activePips[1]]) {
-            const ev = extraVideos[activePips[1]];
-            const srcW = ev.el.videoWidth || 1;
-            const srcH = ev.el.videoHeight || 1;
-            const pipH = Math.floor(pipW * (srcH / srcW));
-            const px = width - pipW - pipMargin;
-            const py = height - pipH - pipMargin;
-            ctx.drawImage(ev.el, px, py, pipW, pipH);
-            ctx.strokeStyle = 'rgba(255,255,255,0.2)';
-            ctx.lineWidth = 1;
-            ctx.strokeRect(px, py, pipW, pipH);
+
+          // Bottom-left [0]
+          if (allCorners[0] !== 'none' && allCorners[0] !== 'map' && allCorners[0] !== selectedAngle) {
+            drawPipAt(allCorners[0], pipMargin, height - defaultPipH - pipMargin);
           }
-          // Top-left (third pip)
-          if (activePips[2] && extraVideos[activePips[2]]) {
-            const ev = extraVideos[activePips[2]];
-            const srcW = ev.el.videoWidth || 1;
-            const srcH = ev.el.videoHeight || 1;
-            const pipH = Math.floor(pipW * (srcH / srcW));
-            const px = pipMargin;
-            const py = pipMargin;
-            ctx.drawImage(ev.el, px, py, pipW, pipH);
-            ctx.strokeStyle = 'rgba(255,255,255,0.2)';
-            ctx.lineWidth = 1;
-            ctx.strokeRect(px, py, pipW, pipH);
+          // Bottom-center [1]
+          if (allCorners[1] !== 'none' && allCorners[1] !== 'map' && allCorners[1] !== selectedAngle) {
+            drawPipAt(allCorners[1], Math.floor((width - pipW) / 2), height - defaultPipH - pipMargin);
+          }
+          // Bottom-right [2]
+          if (allCorners[2] !== 'none' && allCorners[2] !== 'map' && allCorners[2] !== selectedAngle) {
+            drawPipAt(allCorners[2], width - pipW - pipMargin, height - defaultPipH - pipMargin);
+          }
+          // Top-left [3]
+          if (allCorners[3] !== 'none' && allCorners[3] !== 'map' && allCorners[3] !== selectedAngle) {
+            drawPipAt(allCorners[3], pipMargin, pipMargin);
+          }
+          // Top-right [4]
+          if (allCorners[4] !== 'none' && allCorners[4] !== 'map' && allCorners[4] !== selectedAngle) {
+            drawPipAt(allCorners[4], width - pipW - pipMargin, pipMargin);
+          }
+
+          // Draw map at corners configured as 'map'
+          // corner positions: [bottom-left, bottom-center, bottom-right, top-left, top-right]
+          const mapCornerPositions = [
+            { x: pipMargin, y: height - pipW - pipMargin },                         // bottom-left
+            { x: Math.floor((width - pipW) / 2), y: height - pipW - pipMargin },    // bottom-center
+            { x: width - pipW - pipMargin, y: height - pipW - pipMargin },           // bottom-right
+            { x: pipMargin, y: pipMargin },                                          // top-left
+            { x: width - pipW - pipMargin, y: pipMargin },                           // top-right
+          ];
+          const rawPipSei = getSeiForTime(absoluteTime);
+          const pipMapSeiData = rawPipSei?.latitude_deg && rawPipSei?.longitude_deg
+            ? rawPipSei
+            : sequence.event?.est_lat && sequence.event?.est_lon
+              ? { ...(rawPipSei || {}), latitude_deg: sequence.event.est_lat, longitude_deg: sequence.event.est_lon } as typeof rawPipSei
+              : rawPipSei;
+          for (let ci = 0; ci < allCorners.length; ci++) {
+            if (allCorners[ci] === 'map') {
+              const mp = mapCornerPositions[ci];
+              await drawMiniMap(ctx, pipMapSeiData, width, height, { x: mp.x, y: mp.y, size: pipW });
+            }
           }
 
         } else {
@@ -918,8 +946,13 @@ export function VideoExporter({
           ctx.drawImage(tempVideo, 0, 0, width, height);
         }
 
-        // Get SEI data for this absolute time
-        const seiData = getSeiForTime(absoluteTime);
+        // Get SEI data for this absolute time, with event.json GPS fallback
+        const rawSeiData = getSeiForTime(absoluteTime);
+        const seiData = rawSeiData?.latitude_deg && rawSeiData?.longitude_deg
+          ? rawSeiData
+          : sequence.event?.est_lat && sequence.event?.est_lon
+            ? { ...(rawSeiData || {}), latitude_deg: sequence.event.est_lat, longitude_deg: sequence.event.est_lon } as typeof rawSeiData
+            : rawSeiData;
 
         // Draw overlays based on toggle states
         if (showTelemetry) {
@@ -931,7 +964,7 @@ export function VideoExporter({
           const dynamicTime = realTime.toTimeString().split(' ')[0];
           drawDateTime(ctx, width, height, dynamicDate, dynamicTime, showTelemetry);
         }
-        if (showMap) {
+        if (showMap && !(layout === 'pip' && layoutConfig.pip.corners.includes('map'))) {
           await drawMiniMap(ctx, seiData, width, height, layout === 'pip' ? 'top-right' : 'bottom-right');
         }
 
@@ -996,7 +1029,7 @@ export function VideoExporter({
       }
       tempVideo.src = '';
     }
-  }, [sequence, selectedAngle, allSeiMessages, fps, speedUnit, getSeiForTime, getAngleForTime, trimPoints, showTelemetry, showDateTime, showMap, layout]);
+  }, [sequence, selectedAngle, allSeiMessages, fps, speedUnit, getSeiForTime, getAngleForTime, trimPoints, showTelemetry, showDateTime, showMap, layout, layoutConfig]);
 
   const stopExport = useCallback(() => {
     abortRef.current = true;

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -3,7 +3,7 @@
 import { useRef, useEffect, useState, useCallback, lazy, Suspense, ReactNode, useMemo } from 'react';
 import { useSeiData } from '@/hooks/useSeiData';
 import { TelemetryCard } from './TelemetryCard';
-import { VideoSequence, ANGLE_LABELS, ANGLE_ORDER, VideoMoment, TrimPoints, CameraSegment } from '@/types/video';
+import { VideoSequence, ANGLE_LABELS, ANGLE_ORDER, VideoMoment, TrimPoints, CameraSegment, LayoutCameraConfig, DEFAULT_LAYOUT_CONFIG, loadLayoutConfig, saveLayoutConfig } from '@/types/video';
 import { findMomentForTime, toAbsoluteTime } from '@/lib/sequence-detector';
 import {
   IconArrowUp,
@@ -34,8 +34,10 @@ import {
   IconScissors,
   IconWand,
   IconClock,
+  IconSettings2,
 } from '@tabler/icons-react';
 import { VideoExporter } from './VideoExporter';
+import { LayoutConfigPopover } from './LayoutConfigPopover';
 import { TelemetryTimeline } from './TelemetryTimeline';
 import { Tooltip } from './Tooltip';
 
@@ -123,6 +125,20 @@ export function VideoPlayer({
   const [videoAspectRatio, setVideoAspectRatio] = useState<number | null>(null);
   const [isTimelineDragging, setIsTimelineDragging] = useState(false);
 
+  // Layout camera config
+  const [layoutConfig, setLayoutConfig] = useState<LayoutCameraConfig>(DEFAULT_LAYOUT_CONFIG);
+  const [showLayoutConfig, setShowLayoutConfig] = useState(false);
+
+  // Load layout config from localStorage on mount
+  useEffect(() => {
+    setLayoutConfig(loadLayoutConfig());
+  }, []);
+
+  const handleLayoutConfigChange = useCallback((newConfig: LayoutCameraConfig) => {
+    setLayoutConfig(newConfig);
+    saveLayoutConfig(newConfig);
+  }, []);
+
   // Edit mode state
   const [isEditMode, setIsEditMode] = useState(false);
   const [isTrimming, setIsTrimming] = useState(false); // When true, show full timeline for trim adjustment
@@ -158,6 +174,15 @@ export function VideoPlayer({
     currentMomentIndex,
     absoluteTime
   );
+
+  // Map SEI data with event.json GPS fallback
+  const mapSeiData = useMemo(() => {
+    if (seiData?.latitude_deg && seiData?.longitude_deg) return seiData;
+    if (sequence?.event?.est_lat && sequence?.event?.est_lon) {
+      return { ...(seiData || {}), latitude_deg: sequence.event.est_lat, longitude_deg: sequence.event.est_lon } as typeof seiData;
+    }
+    return seiData;
+  }, [seiData, sequence?.event]);
 
   // Reset state when sequence changes
   useEffect(() => {
@@ -624,17 +649,50 @@ export function VideoPlayer({
       );
     }
 
-    // PiP view - main camera with corners
+    // PiP view - main camera with configurable corners
+    // corners: [bottom-left, bottom-center, bottom-right, top-left, top-right]
     if (layout === 'pip') {
-      const pipAngles = ['left_repeater', 'right_repeater', 'back'].filter(
-        a => a !== selectedAngle && availableAngles.includes(a)
-      );
-
+      const corners = layoutConfig.pip.corners;
       const ar = videoAspectRatio || 16 / 9;
+
+      const hasGps = !!(mapSeiData?.latitude_deg && mapSeiData?.longitude_deg);
+
+      // Position classes for each corner slot
+      const cornerPositions = [
+        'absolute bottom-3 left-3',                        // 0: bottom-left
+        'absolute bottom-3 left-1/2 -translate-x-1/2',    // 1: bottom-center
+        'absolute bottom-3 right-3',                       // 2: bottom-right
+        'absolute top-3 left-3',                           // 3: top-left
+        'absolute top-3 right-3',                          // 4: top-right
+      ];
+
+      // Render a single PiP corner element (camera, map, or nothing)
+      const renderPipCorner = (value: string, idx: number) => {
+        if (value === 'none' || value === selectedAngle) return null;
+        const pos = cornerPositions[idx];
+        if (value === 'map') {
+          if (!hasGps) return null;
+          return (
+            <div key={idx} className={`${pos} w-[18%] aspect-square rounded-lg overflow-hidden border border-white/20 shadow-lg pointer-events-auto`}>
+              <Suspense fallback={<div className="bg-gray-900 w-full h-full" />}>
+                <MapView seiData={mapSeiData} />
+              </Suspense>
+            </div>
+          );
+        }
+        if (!availableAngles.includes(value)) return null;
+        return (
+          <div
+            key={idx}
+            className={`${pos} w-[18%] rounded-lg overflow-hidden border border-white/20 shadow-lg pointer-events-none`}
+          >
+            {renderVideo(value, false, 'w-full')}
+          </div>
+        );
+      };
 
       return (
         <div className="relative w-full bg-black flex items-center justify-center aspect-video max-h-full overflow-hidden">
-          {/* Inner wrapper sized to actual video aspect ratio */}
           <div
             className="relative max-w-full max-h-full"
             style={{ aspectRatio: `${ar}` }}
@@ -642,32 +700,8 @@ export function VideoPlayer({
             <div className="w-full h-full">
               {renderVideo(selectedAngle, true, 'w-full h-full')}
             </div>
-            <div className="absolute top-3 right-3 bg-black/60 backdrop-blur-sm rounded px-2 py-1 text-xs font-medium flex items-center gap-1">
-              {ANGLE_ICONS[selectedAngle]} {ANGLE_LABELS[selectedAngle]}
-            </div>
-
-            {/* Corner PiP windows */}
-            <div className="absolute bottom-3 left-3 right-3 flex justify-between pointer-events-none">
-              {pipAngles.slice(0, 2).map((angle) => (
-                <div
-                  key={angle}
-                  className="w-[18%] rounded-lg overflow-hidden border border-white/20 shadow-lg pointer-events-auto cursor-pointer hover:border-blue-400 transition-colors"
-                  onClick={() => handleAngleChange(angle)}
-                >
-                  {renderVideo(angle, false, 'w-full')}
-                </div>
-              ))}
-            </div>
-
-            {/* Optional third PiP in top-left */}
-            {pipAngles[2] && (
-              <div
-                className="absolute top-3 left-3 w-[18%] rounded-lg overflow-hidden border border-white/20 shadow-lg cursor-pointer hover:border-blue-400 transition-colors"
-                onClick={() => handleAngleChange(pipAngles[2])}
-              >
-                {renderVideo(pipAngles[2], false, 'w-full')}
-              </div>
-            )}
+            {/* All 5 PiP corners - each absolutely positioned */}
+            {corners.map((value, idx) => renderPipCorner(value, idx))}
 
             {renderPlayOverlay()}
           </div>
@@ -677,18 +711,18 @@ export function VideoPlayer({
 
     // Triple view - front + left + right in a row
     if (layout === 'triple') {
-      const tripleAngles = ['left_pillar', 'front', 'right_pillar'];
+      const tripleAngles = layoutConfig.triple.cameras;
 
       return (
         <div className="relative w-full bg-black flex items-center justify-center overflow-hidden aspect-video max-h-full">
           <div className="grid grid-cols-3 w-full">
-            {tripleAngles.map((angle) => {
+            {tripleAngles.map((angle, idx) => {
               const isMain = angle === selectedAngle;
               const isAvailable = availableAngles.includes(angle);
 
               return (
                 <div
-                  key={angle}
+                  key={idx}
                   className={`relative overflow-hidden ${
                     isMain ? 'ring-2 ring-inset ring-blue-500' : ''
                   } ${isAvailable ? 'cursor-pointer' : 'opacity-40'}`}
@@ -707,8 +741,8 @@ export function VideoPlayer({
     // All 6 cameras - 2 rows of 3
     if (layout === 'all') {
       const rows = [
-        ['left_repeater', 'left_pillar', 'front'],
-        ['right_repeater', 'right_pillar', 'back'],
+        layoutConfig.all.topRow,
+        layoutConfig.all.bottomRow,
       ];
 
       return (
@@ -716,13 +750,13 @@ export function VideoPlayer({
           <div className="absolute inset-0 flex flex-col gap-1 p-1">
             {rows.map((row, rowIdx) => (
               <div key={rowIdx} className="flex-1 flex gap-1 min-h-0">
-                {row.map((angle) => {
+                {row.map((angle, colIdx) => {
                   const isMain = angle === selectedAngle;
                   const isAvailable = availableAngles.includes(angle);
 
                   return (
                     <div
-                      key={angle}
+                      key={colIdx}
                       className={`relative flex-1 rounded overflow-hidden ${
                         isMain ? 'ring-2 ring-blue-500' : ''
                       } ${isAvailable ? 'cursor-pointer' : 'opacity-40'}`}
@@ -800,8 +834,8 @@ export function VideoPlayer({
               </div>
             )}
 
-            {/* Map Overlay - Top Right for PiP, Bottom Right for others */}
-            {showMap && (
+            {/* Map Overlay - skip if map is already in a PiP corner */}
+            {showMap && !(layout === 'pip' && layoutConfig.pip.corners.includes('map')) && (
               <div className={`absolute w-[180px] h-[180px] rounded-lg overflow-hidden shadow-xl opacity-90 hover:opacity-100 transition-opacity pointer-events-auto ${
                 layout === 'pip' ? 'top-3 right-3' : 'bottom-3 right-3'
               }`}>
@@ -810,7 +844,7 @@ export function VideoPlayer({
                     <div className="text-gray-500 text-xs">Loading...</div>
                   </div>
                 }>
-                  <MapView seiData={seiData} />
+                  <MapView seiData={mapSeiData} />
                 </Suspense>
               </div>
             )}
@@ -935,63 +969,61 @@ export function VideoPlayer({
       {/* Control Bar: Camera + Layout + Date + Toggles */}
       <div className="bg-gray-800/50 rounded-xl px-3 py-2">
         <div className="flex items-center gap-3 flex-wrap">
-          {/* Camera buttons (for single/pip views OR edit mode for camera track) */}
-          {(layout === 'single' || layout === 'pip' || isEditMode || hasCustomCameraTrack) && (
-            <div className="flex items-center gap-1">
-              <span className="text-[10px] text-gray-500 mr-1">Cameras:</span>
-              {ANGLE_ORDER.map((angle) => {
-                const isAvailable = availableAngles.includes(angle);
-                const isActive = selectedAngle === angle && !useCustomCameraTrack;
+          {/* Camera buttons — always visible, disabled for triple/all unless in edit mode */}
+          <div className="flex items-center gap-1">
+            <span className="text-[10px] text-gray-500 mr-1">Cameras:</span>
+            {ANGLE_ORDER.map((angle) => {
+              const isAvailable = availableAngles.includes(angle);
+              const canSelect = layout === 'single' || layout === 'pip' || isEditMode || hasCustomCameraTrack;
+              const isDisabled = !isAvailable || !canSelect;
+              const isActive = selectedAngle === angle && !useCustomCameraTrack && canSelect;
 
-                return (
-                  <Tooltip key={angle} content={ANGLE_LABELS[angle]} position="top">
-                    <button
-                      disabled={!isAvailable}
-                      onClick={() => {
-                        if (isAvailable) {
-                          setUseCustomCameraTrack(false);
-                          handleAngleChange(angle);
-                        }
-                      }}
-                      className={`p-1.5 rounded text-xs font-medium transition-all ${
-                        isActive
-                          ? isEditMode ? 'bg-purple-600 text-white' : 'bg-blue-600 text-white'
-                          : isAvailable
-                          ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-                          : 'bg-gray-800/50 text-gray-600 cursor-not-allowed'
-                      }`}
-                    >
-                      {ANGLE_ICONS[angle]}
-                    </button>
-                  </Tooltip>
-                );
-              })}
-              {/* Custom camera track button */}
-              {hasCustomCameraTrack && (
-                <Tooltip content="Use custom camera track" position="top">
+              return (
+                <Tooltip key={angle} content={ANGLE_LABELS[angle]} position="top">
                   <button
-                    onClick={() => setUseCustomCameraTrack(true)}
-                    className={`px-2 py-1 rounded text-xs font-medium transition-all flex items-center gap-1 ${
-                      useCustomCameraTrack
-                        ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white'
+                    disabled={isDisabled}
+                    onClick={() => {
+                      if (!isDisabled) {
+                        setUseCustomCameraTrack(false);
+                        handleAngleChange(angle);
+                      }
+                    }}
+                    className={`p-1.5 rounded text-xs font-medium transition-all ${
+                      isActive
+                        ? isEditMode ? 'bg-purple-600 text-white' : 'bg-blue-600 text-white'
+                        : isDisabled
+                        ? 'bg-gray-800/50 text-gray-600 cursor-not-allowed'
                         : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
                     }`}
                   >
-                    <IconWand size={14} />
-                    <span>Custom</span>
+                    {ANGLE_ICONS[angle]}
                   </button>
                 </Tooltip>
-              )}
-            </div>
-          )}
+              );
+            })}
+            {/* Custom camera track button */}
+            {hasCustomCameraTrack && (
+              <Tooltip content="Use custom camera track" position="top">
+                <button
+                  onClick={() => setUseCustomCameraTrack(true)}
+                  className={`px-2 py-1 rounded text-xs font-medium transition-all flex items-center gap-1 ${
+                    useCustomCameraTrack
+                      ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white'
+                      : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                  }`}
+                >
+                  <IconWand size={14} />
+                  <span>Custom</span>
+                </button>
+              </Tooltip>
+            )}
+          </div>
 
           {/* Divider */}
-          {(layout === 'single' || layout === 'pip' || isEditMode || hasCustomCameraTrack) && (
-            <div className="w-px h-5 bg-gray-700" />
-          )}
+          <div className="w-px h-5 bg-gray-700" />
 
           {/* Layout buttons */}
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 relative">
             <span className="text-[10px] text-gray-500 mr-1">Layout:</span>
             {LAYOUTS.map((l) => (
               <Tooltip key={l.id} content={l.label} position="top">
@@ -1007,6 +1039,28 @@ export function VideoPlayer({
                 </button>
               </Tooltip>
             ))}
+            {layout !== 'single' && (
+              <Tooltip content="Configure layout" position="top">
+                <button
+                  onClick={() => setShowLayoutConfig(prev => !prev)}
+                  className={`p-1.5 rounded text-xs font-medium transition-all ${
+                    showLayoutConfig
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-700 text-gray-400 hover:bg-gray-600'
+                  }`}
+                >
+                  <IconSettings2 size={14} />
+                </button>
+              </Tooltip>
+            )}
+            {showLayoutConfig && layout !== 'single' && (
+              <LayoutConfigPopover
+                layout={layout}
+                config={layoutConfig}
+                onChange={handleLayoutConfigChange}
+                onClose={() => setShowLayoutConfig(false)}
+              />
+            )}
           </div>
 
           {/* Divider */}
@@ -1110,6 +1164,7 @@ export function VideoPlayer({
               showDateTime={showDateTime}
               showMap={showMap}
               layout={layout}
+              layoutConfig={layoutConfig}
             />
 
             {/* Divider */}

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -103,6 +103,54 @@ export const ANGLE_LABELS: Record<string, string> = {
 
 export const ANGLE_ORDER = ['front', 'left_repeater', 'right_repeater', 'back', 'left_pillar', 'right_pillar'];
 
+/** Camera layout configuration for multi-camera views */
+export interface LayoutCameraConfig {
+  pip: { corners: [string, string, string, string, string] }; // bottom-left, bottom-center, bottom-right, top-left, top-right
+  triple: { cameras: [string, string, string] };               // left, center, right
+  all: { topRow: [string, string, string]; bottomRow: [string, string, string] };
+}
+
+/** Special PiP corner values (besides camera angles) */
+export const PIP_SPECIAL_OPTIONS = ['none', 'map'] as const;
+
+export const DEFAULT_LAYOUT_CONFIG: LayoutCameraConfig = {
+  pip: { corners: ['left_repeater', 'none', 'right_repeater', 'back', 'map'] },
+  triple: { cameras: ['left_pillar', 'front', 'right_pillar'] },
+  all: {
+    topRow: ['left_repeater', 'left_pillar', 'front'],
+    bottomRow: ['right_repeater', 'right_pillar', 'back'],
+  },
+};
+
+const LAYOUT_CONFIG_KEY = 'tesla-cam-layout-config';
+
+export function loadLayoutConfig(): LayoutCameraConfig {
+  try {
+    const stored = localStorage.getItem(LAYOUT_CONFIG_KEY);
+    if (!stored) return { ...DEFAULT_LAYOUT_CONFIG };
+    const parsed = JSON.parse(stored);
+    // Merge with defaults to handle missing/corrupt fields
+    return {
+      pip: { corners: parsed?.pip?.corners?.length === 5 ? parsed.pip.corners : [...DEFAULT_LAYOUT_CONFIG.pip.corners] },
+      triple: { cameras: parsed?.triple?.cameras?.length === 3 ? parsed.triple.cameras : [...DEFAULT_LAYOUT_CONFIG.triple.cameras] },
+      all: {
+        topRow: parsed?.all?.topRow?.length === 3 ? parsed.all.topRow : [...DEFAULT_LAYOUT_CONFIG.all.topRow],
+        bottomRow: parsed?.all?.bottomRow?.length === 3 ? parsed.all.bottomRow : [...DEFAULT_LAYOUT_CONFIG.all.bottomRow],
+      },
+    };
+  } catch {
+    return { ...DEFAULT_LAYOUT_CONFIG };
+  }
+}
+
+export function saveLayoutConfig(config: LayoutCameraConfig): void {
+  try {
+    localStorage.setItem(LAYOUT_CONFIG_KEY, JSON.stringify(config));
+  } catch {
+    // Silently fail if localStorage is full or unavailable
+  }
+}
+
 /** Trim points for video export */
 export interface TrimPoints {
   inPoint: number;   // Start time in seconds


### PR DESCRIPTION
Allow users to configure which cameras appear in each position for PiP, Triple, and All 6 layouts. Includes a centered config dialog with screen simulation, 5-corner PiP with map option, localStorage persistence, and export sync.

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added camera layout configuration UI supporting Picture-in-Picture, Triple, and All-camera modes
  * Users can now customize camera angle selections for each layout
  * Layout preferences are automatically saved and restored between sessions
  * Enhanced video export with layout-aware rendering and camera configuration support
  * Improved map data accuracy with GPS coordinate fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->