### PR TITLE
fix: overlay display order, DateTime positioning, and config persistence

### DIFF
--- a/src/components/TelemetryTimeline.tsx
+++ b/src/components/TelemetryTimeline.tsx
@@ -749,7 +749,7 @@ export function TelemetryTimeline({
 
         {/* Playhead */}
         <div
-          className={`absolute top-0 bottom-0 w-0.5 bg-white shadow-lg z-10 pointer-events-none ${
+          className={`absolute top-0 bottom-0 w-0.5 bg-white shadow-lg z-[16] pointer-events-none ${
             isDragging ? 'w-1' : ''
           }`}
           style={{ left: `${playheadPosition}%` }}

--- a/src/components/VideoExporter.tsx
+++ b/src/components/VideoExporter.tsx
@@ -439,7 +439,8 @@ export function VideoExporter({
     height: number,
     date: string,
     time: string,
-    telemetryVisible: boolean
+    telemetryVisible: boolean,
+    isAutopilotActive: boolean
   ) => {
     const isPortrait = height > width;
     const scale = isPortrait
@@ -465,8 +466,13 @@ export function VideoExporter({
       const circleGap = 5 * scale;
       const telemetryBoxHeight = circleSize * 2 + circleGap + padding * 2;
       const telemetryY = 12 * scale;
-      // Position just below telemetry with a small gap
-      y = telemetryY + telemetryBoxHeight + 8 * scale;
+      let telemetryBottom = telemetryY + telemetryBoxHeight;
+      if (isAutopilotActive) {
+        // Autopilot label in drawTelemetry starts at (y + boxHeight - 1) with height 20*scale
+        telemetryBottom = telemetryY + telemetryBoxHeight - 1 + 20 * scale;
+      }
+      // Position just below telemetry (or autopilot label) with a small gap
+      y = telemetryBottom + 8 * scale;
     } else {
       // Position at top center
       y = 12 * scale;
@@ -1127,7 +1133,9 @@ export function VideoExporter({
           const realTime = new Date(moment.timestamp.getTime() + localTime * 1000);
           const dynamicDate = realTime.toISOString().split('T')[0];
           const dynamicTime = realTime.toTimeString().split(' ')[0];
-          drawDateTime(ctx, overlayW, overlayH, dynamicDate, dynamicTime, showTelemetry);
+          const autopilotState = seiData?.autopilot_state ?? 0;
+          const isAutopilotActive = showTelemetry && [1, 2, 3].includes(autopilotState);
+          drawDateTime(ctx, overlayW, overlayH, dynamicDate, dynamicTime, showTelemetry, isAutopilotActive);
         }
         if (showMap && !(isPortraitFormat && pLayoutMeta.hasMap) && !(layout === 'pip' && layoutConfig.pip.corners.includes('map'))) {
           await drawMiniMap(ctx, seiData, overlayW, overlayH, layout === 'pip' ? 'top-right' : 'bottom-right');

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -116,7 +116,10 @@ function loadOverlayConfig(): Record<string, unknown> {
   try {
     const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
     if (saved) {
-      return JSON.parse(saved);
+      const parsed: unknown = JSON.parse(saved);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
     }
   } catch { /* ignore corrupt localStorage */ }
   return {};
@@ -142,23 +145,22 @@ export function VideoPlayer({
   const [localTime, setLocalTime] = useState(0);  // Time within current clip
   const [isPlaying, setIsPlaying] = useState(false);
 
-  const [speedUnit, setSpeedUnit] = useState<'mph' | 'kmh'>(() => {
-    const c = loadOverlayConfig();
-    return c.speedUnit === 'mph' || c.speedUnit === 'kmh' ? c.speedUnit : 'mph';
-  });
+  // Read overlay config once from localStorage for all initial states
+  const [initConfig] = useState(loadOverlayConfig);
+
+  const [speedUnit, setSpeedUnit] = useState<'mph' | 'kmh'>(
+    initConfig.speedUnit === 'mph' || initConfig.speedUnit === 'kmh' ? initConfig.speedUnit : 'mph'
+  );
   const [playbackRate, setPlaybackRate] = useState(1);
-  const [showMap, setShowMap] = useState<boolean>(() => {
-    const c = loadOverlayConfig();
-    return typeof c.showMap === 'boolean' ? c.showMap : true;
-  });
-  const [showTelemetry, setShowTelemetry] = useState<boolean>(() => {
-    const c = loadOverlayConfig();
-    return typeof c.showTelemetry === 'boolean' ? c.showTelemetry : true;
-  });
-  const [showDateTime, setShowDateTime] = useState<boolean>(() => {
-    const c = loadOverlayConfig();
-    return typeof c.showDateTime === 'boolean' ? c.showDateTime : true;
-  });
+  const [showMap, setShowMap] = useState<boolean>(
+    typeof initConfig.showMap === 'boolean' ? initConfig.showMap : true
+  );
+  const [showTelemetry, setShowTelemetry] = useState<boolean>(
+    typeof initConfig.showTelemetry === 'boolean' ? initConfig.showTelemetry : true
+  );
+  const [showDateTime, setShowDateTime] = useState<boolean>(
+    typeof initConfig.showDateTime === 'boolean' ? initConfig.showDateTime : true
+  );
 
   // Persist overlay toggle states to localStorage
   useEffect(() => {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1010,7 +1010,7 @@ export function VideoPlayer({
             {showDateTime && (
               <div className={`absolute left-1/2 -translate-x-1/2 pointer-events-none ${
                 showTelemetry
-                  ? (seiData?.autopilot_state ?? 0) > 0 ? 'top-[105px]' : 'top-[95px]'
+                  ? [1, 2, 3].includes(seiData?.autopilot_state ?? 0) ? 'top-[105px]' : 'top-[95px]'
                   : 'top-3'
               }`}>
                 <div className="px-2 py-1 rounded-md bg-black/50 backdrop-blur-sm text-white/90 text-xs font-medium">

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -112,6 +112,16 @@ const LAYOUTS: LayoutConfig[] = [
   },
 ];
 
+function loadOverlayConfig(): Record<string, unknown> {
+  try {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
+    if (saved) {
+      return JSON.parse(saved);
+    }
+  } catch { /* ignore corrupt localStorage */ }
+  return {};
+}
+
 export function VideoPlayer({
   sequences,
   selectedSequence: sequence,
@@ -133,33 +143,21 @@ export function VideoPlayer({
   const [isPlaying, setIsPlaying] = useState(false);
 
   const [speedUnit, setSpeedUnit] = useState<'mph' | 'kmh'>(() => {
-    try {
-      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
-      if (saved) { const c = JSON.parse(saved); if (c.speedUnit === 'mph' || c.speedUnit === 'kmh') return c.speedUnit; }
-    } catch { /* ignore */ }
-    return 'mph';
+    const c = loadOverlayConfig();
+    return c.speedUnit === 'mph' || c.speedUnit === 'kmh' ? c.speedUnit : 'mph';
   });
   const [playbackRate, setPlaybackRate] = useState(1);
   const [showMap, setShowMap] = useState<boolean>(() => {
-    try {
-      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
-      if (saved) { const c = JSON.parse(saved); if (typeof c.showMap === 'boolean') return c.showMap; }
-    } catch { /* ignore */ }
-    return true;
+    const c = loadOverlayConfig();
+    return typeof c.showMap === 'boolean' ? c.showMap : true;
   });
   const [showTelemetry, setShowTelemetry] = useState<boolean>(() => {
-    try {
-      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
-      if (saved) { const c = JSON.parse(saved); if (typeof c.showTelemetry === 'boolean') return c.showTelemetry; }
-    } catch { /* ignore */ }
-    return true;
+    const c = loadOverlayConfig();
+    return typeof c.showTelemetry === 'boolean' ? c.showTelemetry : true;
   });
   const [showDateTime, setShowDateTime] = useState<boolean>(() => {
-    try {
-      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
-      if (saved) { const c = JSON.parse(saved); if (typeof c.showDateTime === 'boolean') return c.showDateTime; }
-    } catch { /* ignore */ }
-    return true;
+    const c = loadOverlayConfig();
+    return typeof c.showDateTime === 'boolean' ? c.showDateTime : true;
   });
 
   // Persist overlay toggle states to localStorage

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -131,11 +131,48 @@ export function VideoPlayer({
   const [currentMomentIndex, setCurrentMomentIndex] = useState(0);
   const [localTime, setLocalTime] = useState(0);  // Time within current clip
   const [isPlaying, setIsPlaying] = useState(false);
-  const [speedUnit, setSpeedUnit] = useState<'mph' | 'kmh'>('mph');
+
+  const [speedUnit, setSpeedUnit] = useState<'mph' | 'kmh'>(() => {
+    try {
+      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
+      if (saved) { const c = JSON.parse(saved); if (c.speedUnit === 'mph' || c.speedUnit === 'kmh') return c.speedUnit; }
+    } catch { /* ignore */ }
+    return 'mph';
+  });
   const [playbackRate, setPlaybackRate] = useState(1);
-  const [showMap, setShowMap] = useState(true);
-  const [showTelemetry, setShowTelemetry] = useState(true);
-  const [showDateTime, setShowDateTime] = useState(true);
+  const [showMap, setShowMap] = useState<boolean>(() => {
+    try {
+      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
+      if (saved) { const c = JSON.parse(saved); if (typeof c.showMap === 'boolean') return c.showMap; }
+    } catch { /* ignore */ }
+    return true;
+  });
+  const [showTelemetry, setShowTelemetry] = useState<boolean>(() => {
+    try {
+      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
+      if (saved) { const c = JSON.parse(saved); if (typeof c.showTelemetry === 'boolean') return c.showTelemetry; }
+    } catch { /* ignore */ }
+    return true;
+  });
+  const [showDateTime, setShowDateTime] = useState<boolean>(() => {
+    try {
+      const saved = typeof window !== 'undefined' ? localStorage.getItem('exportdash-overlay-config') : null;
+      if (saved) { const c = JSON.parse(saved); if (typeof c.showDateTime === 'boolean') return c.showDateTime; }
+    } catch { /* ignore */ }
+    return true;
+  });
+
+  // Persist overlay toggle states to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem('exportdash-overlay-config', JSON.stringify({
+        showTelemetry,
+        showMap,
+        showDateTime,
+        speedUnit,
+      }));
+    } catch { /* ignore localStorage write errors */ }
+  }, [showTelemetry, showMap, showDateTime, speedUnit]);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [videoAspectRatio, setVideoAspectRatio] = useState<number | null>(null);
   const [isTimelineDragging, setIsTimelineDragging] = useState(false);
@@ -972,7 +1009,9 @@ export function VideoPlayer({
             {/* Date/Time Overlay - Below Telemetry or Top Center */}
             {showDateTime && (
               <div className={`absolute left-1/2 -translate-x-1/2 pointer-events-none ${
-                showTelemetry ? 'top-[95px]' : 'top-3'
+                showTelemetry
+                  ? (seiData?.autopilot_state ?? 0) > 0 ? 'top-[105px]' : 'top-[95px]'
+                  : 'top-3'
               }`}>
                 <div className="px-2 py-1 rounded-md bg-black/50 backdrop-blur-sm text-white/90 text-xs font-medium">
                   {(() => {
@@ -1345,6 +1384,16 @@ export function VideoPlayer({
                 <IconBolt size={16} />
               </button>
             </Tooltip>
+            {showTelemetry && (
+              <Tooltip content={`Speed: ${speedUnit === 'mph' ? 'mph' : 'km/h'} (click to switch)`} position="top">
+                <button
+                  onClick={() => setSpeedUnit(prev => prev === 'mph' ? 'kmh' : 'mph')}
+                  className="px-1.5 h-[28px] flex items-center rounded transition-all bg-gray-700 text-gray-300 hover:bg-gray-600 text-[10px] font-bold leading-none"
+                >
+                  {speedUnit === 'mph' ? 'MPH' : 'KMH'}
+                </button>
+              </Tooltip>
+            )}
             <Tooltip content="Map (M)" position="top">
               <button
                 onClick={() => setShowMap(prev => !prev)}
@@ -1367,14 +1416,6 @@ export function VideoPlayer({
                 }`}
               >
                 <IconClock size={16} />
-              </button>
-            </Tooltip>
-            <Tooltip content={`Speed: ${speedUnit === 'mph' ? 'mph' : 'km/h'} (click to switch)`} position="top">
-              <button
-                onClick={() => setSpeedUnit(prev => prev === 'mph' ? 'kmh' : 'mph')}
-                className="px-1.5 h-[28px] flex items-center rounded transition-all bg-gray-700 text-gray-300 hover:bg-gray-600 text-[10px] font-bold leading-none"
-              >
-                {speedUnit === 'mph' ? 'MPH' : 'KMH'}
               </button>
             </Tooltip>
 


### PR DESCRIPTION
## Summary
Rebased and resolved conflicts from PR #19 by @TioaChan.

Original changes:
- **Overlay config persistence** — reads/writes `showTelemetry`, `showMap`, `showDateTime`, `speedUnit` to localStorage
- **DateTime position accounts for autopilot label** — shifts DateTime overlay down when autopilot state is active (both preview and export)
- **UI polish** — speed unit button moved next to telemetry toggle; playhead z-index adjusted

Conflict resolution: the export pipeline now uses `overlayW`/`overlayH` variables (introduced in social media presets feature) instead of raw `width`/`height`.

Closes #19

## Test plan
- [ ] Toggle telemetry/map/datetime overlays, reload page — verify settings persist
- [ ] Enable telemetry with autopilot active — verify DateTime is positioned below the autopilot label
- [ ] Export a video with autopilot active — verify DateTime doesn't overlap autopilot label
- [ ] Verify speed unit toggle appears only when telemetry is visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playhead positioning to prevent overlap with other visual elements
  * Improved date/time overlay positioning when autopilot is active

* **New Features**
  * Overlay settings are now saved and persisted across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->