### PR TITLE
Decrypt Tesla 2026.20+ encrypted dashcam clips in-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Interactive Map** — Live GPS tracking synced with video playback
 - **Event Timeline** — Visual timeline showing brake, gas, turn signals, and steering events
 - **Video Export** — Export clips with telemetry burned into the video
+- **Encrypted Clip Support** — Decrypt Tesla 2026.20+ encrypted recordings in-browser using your Tesla account token
 - **100% Client-Side** — All processing happens in your browser, no uploads required
 
 ## Deploy
@@ -87,6 +88,35 @@ Clip 5: 10:34:00 (60s) ─┘
 Clip 6: 10:45:00 (60s) ─→ New sequence (12min gap)
 ```
 
+## Encrypted Clips (firmware 2026.20+)
+
+Recent Tesla firmware encrypts dashcam and Sentry recordings on the USB drive.
+When you drop encrypted clips, ExportDash detects them and offers to decrypt
+them in your browser:
+
+1. Sign in at [dashcam.tesla.com](https://dashcam.tesla.com) and grab your
+   dashcam token from DevTools → Network → any `/api/1/` request →
+   `Authorization: Bearer …`.
+2. Paste it into the prompt. ExportDash fetches the per-file decryption keys from
+   Tesla and decrypts the video locally.
+
+**How it stays private:**
+
+- Your video **never leaves your device** — decryption runs entirely in the
+  browser using the native WebCrypto AES engine.
+- Only per-file identifiers and ownership metadata (never footage) are sent to
+  Tesla to retrieve the decryption keys — exactly what Tesla's own web viewer
+  sends.
+- Your token is stored only in your browser (localStorage, opt-in "remember")
+  and is sent only to Tesla. Treat it like a password; it expires periodically.
+
+**Why a proxy:** browsers can't call `dashcam.tesla.com` directly from another
+origin (CORS). The key request is routed same-origin through a thin reverse
+proxy that forwards only to Tesla — the Next.js dev server handles this locally,
+and nginx handles it in production (see `nginx.conf`). Point it elsewhere with
+`NEXT_PUBLIC_TESLA_KEY_URL` if needed. The proxy adds no credentials of its own;
+it only relays your authenticated request to Tesla.
+
 ## Tech Stack
 
 - **Framework:** Next.js 15 with App Router
@@ -123,11 +153,14 @@ src/
 │   ├── MapView.tsx       # GPS map overlay
 │   ├── VideoExporter.tsx # WebCodecs-based export
 │   ├── DropZone.tsx      # File/folder drop handling
+│   ├── DecryptDialog.tsx # Encrypted-clip token prompt & decrypt progress
 │   └── LoadingScreen.tsx # Processing progress UI
 ├── hooks/
 │   └── useSeiData.ts     # SEI extraction & time sync
 ├── lib/
 │   ├── dashcam-mp4.ts    # MP4 parsing & SEI extraction
+│   ├── tesla-crypto.ts   # MD5 + AES-128-CBC primitives (verified vs test vectors)
+│   ├── tesla-decrypt.ts  # Encrypted container parsing, key fetch & decryption
 │   └── sequence-detector.ts # Clip merging logic
 └── types/
     └── video.ts          # TypeScript definitions

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,22 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  // Dev-only: proxy the Tesla decryption-key endpoint through the dev server so
+  // the browser makes a same-origin request (no CORS). In production the app is
+  // static (`output: "export"`), so this rewrite is omitted from the build and
+  // nginx performs the same proxy (see nginx.conf `/tesla-decrypt/`).
+  ...(process.env.NODE_ENV === "development"
+    ? {
+        async rewrites() {
+          return [
+            {
+              source: "/tesla-decrypt/:path*",
+              destination: "https://dashcam.tesla.com/:path*",
+            },
+          ];
+        },
+      }
+    : {}),
 };
 
 export default nextConfig;

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,6 +16,21 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Proxy the Tesla decryption-key endpoint so the browser makes a
+    # same-origin request (avoids CORS). Only file identifiers and ownership
+    # metadata pass through here — never video. The upstream request is made
+    # server-to-server with Tesla's own Origin/Referer, mirroring the official
+    # web viewer.
+    location /tesla-decrypt/ {
+        proxy_pass https://dashcam.tesla.com/;
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_set_header Host dashcam.tesla.com;
+        proxy_set_header Origin https://dashcam.tesla.com;
+        proxy_set_header Referer https://dashcam.tesla.com/;
+        proxy_set_header Accept-Encoding "";
+    }
+
     # SPA fallback - serve index.html for all routes
     location / {
         try_files $uri $uri.html $uri/ /index.html;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,19 @@ import { useState, useCallback } from 'react';
 import { DropZone } from '@/components/DropZone';
 import { VideoPlayer } from '@/components/VideoPlayer';
 import { LoadingScreen } from '@/components/LoadingScreen';
+import { DecryptDialog } from '@/components/DecryptDialog';
 import { VideoSequence, ProcessingProgress } from '@/types/video';
 import { processFilesToMoments, detectSequences } from '@/lib/sequence-detector';
+import {
+  isEncryptedTeslaFile,
+  parseTeslaHeader,
+  fetchDecryptKeys,
+  decryptTeslaFile,
+  loadStoredToken,
+  saveStoredToken,
+  clearStoredToken,
+  KeyFetchError,
+} from '@/lib/tesla-decrypt';
 
 export default function Home() {
   const [sequences, setSequences] = useState<VideoSequence[]>([]);
@@ -16,30 +27,27 @@ export default function Home() {
     current: 0,
     total: 0,
   });
+  // Encrypted clips awaiting a token before they can be decrypted.
+  const [pendingDecrypt, setPendingDecrypt] = useState<{ encrypted: File[]; plain: File[] } | null>(
+    null
+  );
 
-  const handleFilesAdded = useCallback(async (newFiles: File[]) => {
-    if (newFiles.length === 0) return;
+  // Run the normal processing pipeline on a set of plain (decrypted) MP4 files.
+  const runPipeline = useCallback(async (files: File[]) => {
+    if (files.length === 0) return;
 
-    // Start processing
     setIsProcessing(true);
     setProcessingProgress({
       stage: 'scanning',
       current: 0,
-      total: newFiles.length,
+      total: files.length,
       message: 'Scanning files...',
     });
 
     try {
-      // Process files into moments (also parses event.json files)
-      const { moments, events } = await processFilesToMoments(newFiles, setProcessingProgress);
-
-      // Detect sequences from moments, matching events to sequences
+      const { moments, events } = await processFilesToMoments(files, setProcessingProgress);
       const detectedSequences = detectSequences(moments, events);
-
-      // Update state
       setSequences(detectedSequences);
-
-      // Auto-select first sequence if none selected
       if (detectedSequences.length > 0) {
         setSelectedSequence(detectedSequences[0]);
       }
@@ -48,13 +56,84 @@ export default function Home() {
       setProcessingProgress({
         stage: 'error',
         current: 0,
-        total: newFiles.length,
+        total: files.length,
         message: 'Error processing videos',
       });
     } finally {
       setIsProcessing(false);
     }
   }, []);
+
+  const handleFilesAdded = useCallback(
+    async (newFiles: File[]) => {
+      if (newFiles.length === 0) return;
+
+      // Split off any Tesla-encrypted clips; they need a key before playback.
+      const encrypted: File[] = [];
+      const plain: File[] = [];
+      for (const file of newFiles) {
+        if (file.name.toLowerCase().endsWith('.mp4') && (await isEncryptedTeslaFile(file))) {
+          encrypted.push(file);
+        } else {
+          plain.push(file);
+        }
+      }
+
+      if (encrypted.length > 0) {
+        // Prompt for the Tesla token; decryption continues in handleDecrypt.
+        setPendingDecrypt({ encrypted, plain });
+        return;
+      }
+
+      await runPipeline(newFiles);
+    },
+    [runPipeline]
+  );
+
+  // Called by the decrypt dialog: fetch keys, decrypt every encrypted clip in
+  // the browser, then hand the resulting plain MP4s to the normal pipeline.
+  const handleDecrypt = useCallback(
+    async (
+      token: string,
+      remember: boolean,
+      onProgress: (label: string, fraction: number) => void
+    ) => {
+      if (!pendingDecrypt) return;
+      const { encrypted, plain } = pendingDecrypt;
+
+      const buffers = await Promise.all(
+        encrypted.map(async (f) => new Uint8Array(await f.arrayBuffer()))
+      );
+      const headers = buffers.map(parseTeslaHeader);
+
+      onProgress('Fetching keys from Tesla…', 0);
+      const keys = await fetchDecryptKeys(headers, token, (done, total) => {
+        if (total > 1) onProgress(`Fetching keys from Tesla… (batch ${done}/${total})`, 0);
+      });
+
+      const decryptedFiles: File[] = [];
+      for (let i = 0; i < encrypted.length; i++) {
+        const key = keys.get(headers[i].id);
+        if (!key) {
+          throw new KeyFetchError(
+            `Tesla didn't return a key for "${encrypted[i].name}". The token may lack access to this vehicle.`
+          );
+        }
+        const label = `Decrypting ${encrypted[i].name} (${i + 1}/${encrypted.length})…`;
+        const blob = await decryptTeslaFile(buffers[i], key, (frac) => onProgress(label, frac));
+        decryptedFiles.push(new File([blob], encrypted[i].name, { type: 'video/mp4' }));
+      }
+
+      // Persist or forget the token per the user's choice.
+      if (remember) saveStoredToken(token);
+      else clearStoredToken();
+
+      // Success: close the dialog and process the decrypted clips + any plain ones.
+      setPendingDecrypt(null);
+      void runPipeline([...plain, ...decryptedFiles]);
+    },
+    [pendingDecrypt, runPipeline]
+  );
 
   const handleClear = useCallback(() => {
     setSequences([]);
@@ -65,6 +144,21 @@ export default function Home() {
     <div className="min-h-screen bg-gray-950 text-white">
       {/* Loading Screen */}
       {isProcessing && <LoadingScreen progress={processingProgress} />}
+
+      {/* Decrypt prompt for encrypted Tesla clips */}
+      {pendingDecrypt && (
+        <DecryptDialog
+          fileCount={pendingDecrypt.encrypted.length}
+          initialToken={loadStoredToken() ?? ''}
+          onCancel={() => {
+            // Skip decryption, but still play any plain clips dropped alongside.
+            const plain = pendingDecrypt.plain;
+            setPendingDecrypt(null);
+            if (plain.length > 0) void runPipeline(plain);
+          }}
+          onDecrypt={handleDecrypt}
+        />
+      )}
 
       {/* Main Content - Full width, no header */}
       <main className="p-4">

--- a/src/components/DecryptDialog.tsx
+++ b/src/components/DecryptDialog.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  IconLock,
+  IconKey,
+  IconShieldLock,
+  IconAlertTriangle,
+  IconLoader2,
+  IconExternalLink,
+  IconX,
+  IconEye,
+  IconEyeOff,
+} from '@tabler/icons-react';
+
+interface DecryptDialogProps {
+  /** How many dropped clips are encrypted. */
+  fileCount: number;
+  /** Token remembered on this device, if any (pre-fills the input). */
+  initialToken?: string;
+  onCancel: () => void;
+  /**
+   * Perform decryption. Should throw on failure (invalid token, CORS, etc.);
+   * the dialog stays open and shows the error. `onProgress` reports the file
+   * currently being decrypted and its 0..1 completion.
+   */
+  onDecrypt: (
+    token: string,
+    remember: boolean,
+    onProgress: (label: string, fraction: number) => void
+  ) => Promise<void>;
+}
+
+export function DecryptDialog({ fileCount, initialToken = '', onCancel, onDecrypt }: DecryptDialogProps) {
+  const [token, setToken] = useState(initialToken);
+  const [remember, setRemember] = useState(true);
+  const [showToken, setShowToken] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progressLabel, setProgressLabel] = useState('');
+  const [progressFraction, setProgressFraction] = useState(0);
+
+  const canDecrypt = token.trim().length > 0 && !busy;
+
+  const handleDecrypt = async () => {
+    if (!canDecrypt) return;
+    setBusy(true);
+    setError(null);
+    setProgressLabel('Fetching keys from Tesla…');
+    setProgressFraction(0);
+    try {
+      await onDecrypt(token.trim(), remember, (label, fraction) => {
+        setProgressLabel(label);
+        setProgressFraction(fraction);
+      });
+      // On success the parent unmounts this dialog.
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Decryption failed.');
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-gray-950/90 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="relative w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl bg-gray-900 border border-gray-800 shadow-2xl">
+        {/* Close */}
+        {!busy && (
+          <button
+            onClick={onCancel}
+            className="absolute right-4 top-4 text-gray-500 hover:text-gray-300 transition-colors"
+            aria-label="Cancel"
+          >
+            <IconX size={20} />
+          </button>
+        )}
+
+        <div className="p-6">
+          {/* Header */}
+          <div className="flex items-start gap-3 mb-4">
+            <div className="w-11 h-11 rounded-xl bg-amber-500/15 flex items-center justify-center flex-shrink-0">
+              <IconLock size={22} className="text-amber-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-white">
+                {fileCount === 1 ? 'Encrypted clip detected' : `${fileCount} encrypted clips detected`}
+              </h2>
+              <p className="text-sm text-gray-400 mt-0.5">
+                Recent Tesla firmware (2026.20+) encrypts dashcam recordings on the USB drive. To
+                play them here, they need to be decrypted first.
+              </p>
+            </div>
+          </div>
+
+          {/* How it works / how to get token */}
+          <div className="rounded-xl bg-gray-800/50 border border-gray-700/60 p-4 mb-4">
+            <div className="flex items-center gap-2 mb-2">
+              <IconKey size={16} className="text-blue-400" />
+              <span className="text-sm font-medium text-gray-200">Get your Tesla dashcam token</span>
+            </div>
+            <ol className="text-sm text-gray-400 space-y-1.5 list-decimal list-inside">
+              <li>
+                Open{' '}
+                <a
+                  href="https://dashcam.tesla.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 hover:text-blue-300 inline-flex items-center gap-0.5"
+                >
+                  dashcam.tesla.com <IconExternalLink size={13} />
+                </a>{' '}
+                and sign in with your Tesla account.
+              </li>
+              <li>
+                Open your browser&apos;s DevTools (<span className="font-mono text-xs text-gray-300">F12</span>) →{' '}
+                <span className="text-gray-300">Network</span> tab.
+              </li>
+              <li>Drag any encrypted clip onto that page so it makes a request.</li>
+              <li>
+                Click a request to <span className="font-mono text-xs text-gray-300">/api/1/</span> → in{' '}
+                <span className="text-gray-300">Headers</span>, copy the value after{' '}
+                <span className="font-mono text-xs text-gray-300">Authorization: Bearer</span>.
+              </li>
+            </ol>
+          </div>
+
+          {/* Token input */}
+          <label className="block text-sm font-medium text-gray-300 mb-1.5">Tesla token</label>
+          <div className="relative mb-3">
+            <input
+              type={showToken ? 'text' : 'password'}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              disabled={busy}
+              placeholder="Paste your Bearer token…"
+              spellCheck={false}
+              autoComplete="off"
+              className="w-full rounded-lg bg-gray-950 border border-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none text-sm text-gray-100 font-mono px-3 py-2.5 pr-10 disabled:opacity-60"
+            />
+            <button
+              type="button"
+              onClick={() => setShowToken((v) => !v)}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
+              aria-label={showToken ? 'Hide token' : 'Show token'}
+            >
+              {showToken ? <IconEyeOff size={18} /> : <IconEye size={18} />}
+            </button>
+          </div>
+
+          {/* Remember */}
+          <label className="flex items-center gap-2 mb-4 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={remember}
+              onChange={(e) => setRemember(e.target.checked)}
+              disabled={busy}
+              className="w-4 h-4 rounded border-gray-600 bg-gray-950 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm text-gray-300">Remember this token on this device</span>
+          </label>
+
+          {/* Security info */}
+          <div className="rounded-xl bg-emerald-500/5 border border-emerald-500/20 p-4 mb-4">
+            <div className="flex items-center gap-2 mb-2">
+              <IconShieldLock size={16} className="text-emerald-400" />
+              <span className="text-sm font-medium text-emerald-300">Your privacy &amp; security</span>
+            </div>
+            <ul className="text-xs text-gray-400 space-y-1.5">
+              <li className="flex gap-2">
+                <span className="text-emerald-500">•</span>
+                <span>
+                  Your video never leaves your device. Decryption happens entirely in your browser.
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="text-emerald-500">•</span>
+                <span>
+                  Only per-file identifiers are sent to Tesla to retrieve the decryption keys — never
+                  the footage itself.
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="text-amber-500">•</span>
+                <span>
+                  Your token grants access to your Tesla dashcam account — treat it like a password.
+                  It&apos;s stored only {remember ? 'in this browser (localStorage)' : 'in memory for this session'} and
+                  is sent only to Tesla.
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="text-amber-500">•</span>
+                <span>Tokens expire periodically; grab a fresh one if decryption fails.</span>
+              </li>
+            </ul>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="rounded-xl bg-red-500/10 border border-red-500/30 p-3 mb-4 flex gap-2">
+              <IconAlertTriangle size={18} className="text-red-400 flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-red-300">{error}</p>
+            </div>
+          )}
+
+          {/* Progress */}
+          {busy && (
+            <div className="mb-4">
+              <div className="flex items-center gap-2 text-sm text-gray-300 mb-2">
+                <IconLoader2 size={16} className="animate-spin text-blue-400" />
+                <span className="truncate">{progressLabel}</span>
+              </div>
+              <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-gradient-to-r from-blue-600 to-blue-400 rounded-full transition-all duration-200"
+                  style={{ width: `${Math.round(progressFraction * 100)}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              onClick={onCancel}
+              disabled={busy}
+              className="flex-1 px-4 py-2.5 rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors disabled:opacity-50 text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleDecrypt}
+              disabled={!canDecrypt}
+              className="flex-1 px-4 py-2.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium inline-flex items-center justify-center gap-2"
+            >
+              {busy ? (
+                <>
+                  <IconLoader2 size={16} className="animate-spin" /> Decrypting…
+                </>
+              ) : (
+                <>
+                  <IconLock size={16} /> Decrypt {fileCount === 1 ? 'clip' : `${fileCount} clips`}
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tesla-crypto.ts
+++ b/src/lib/tesla-crypto.ts
@@ -1,0 +1,297 @@
+/**
+ * Self-contained crypto primitives for decrypting Tesla dashcam containers.
+ *
+ * Two primitives are needed that the browser's WebCrypto API does not provide
+ * in a usable form here:
+ *
+ *   1. MD5 — used to derive each page's IV. WebCrypto has no MD5.
+ *   2. Raw AES-128-CBC (no PKCS7 padding) — each 4096-byte page is a whole
+ *      number of blocks with no padding byte. WebCrypto's AES-CBC always
+ *      appends/strips PKCS7, so it cannot decrypt these pages as-is.
+ *
+ * Both implementations are standard and verified against published test
+ * vectors (see tesla-crypto.test.ts / the round-trip check in scripts).
+ */
+
+// ── MD5 ─────────────────────────────────────────────────────────────────────
+
+function md5cmn(q: number, a: number, b: number, x: number, s: number, t: number): number {
+  a = (((a + q) | 0) + ((x + t) | 0)) | 0;
+  return (((a << s) | (a >>> (32 - s))) + b) | 0;
+}
+function md5ff(a: number, b: number, c: number, d: number, x: number, s: number, t: number) {
+  return md5cmn((b & c) | (~b & d), a, b, x, s, t);
+}
+function md5gg(a: number, b: number, c: number, d: number, x: number, s: number, t: number) {
+  return md5cmn((b & d) | (c & ~d), a, b, x, s, t);
+}
+function md5hh(a: number, b: number, c: number, d: number, x: number, s: number, t: number) {
+  return md5cmn(b ^ c ^ d, a, b, x, s, t);
+}
+function md5ii(a: number, b: number, c: number, d: number, x: number, s: number, t: number) {
+  return md5cmn(c ^ (b | ~d), a, b, x, s, t);
+}
+
+/** Compute the MD5 digest of a byte array. Returns 16 raw bytes. */
+export function md5(input: Uint8Array): Uint8Array {
+  const len = input.length;
+  // Pad message: append 0x80, then zeros, then 64-bit little-endian bit length.
+  const withPad = ((len + 8) >> 6) + 1;
+  const words = new Int32Array(withPad * 16);
+  for (let i = 0; i < len; i++) {
+    words[i >> 2] |= input[i] << ((i % 4) * 8);
+  }
+  words[len >> 2] |= 0x80 << ((len % 4) * 8);
+  words[withPad * 16 - 2] = len * 8;
+
+  let a = 1732584193;
+  let b = -271733879;
+  let c = -1732584194;
+  let d = 271733878;
+
+  for (let i = 0; i < words.length; i += 16) {
+    const oa = a, ob = b, oc = c, od = d;
+
+    a = md5ff(a, b, c, d, words[i + 0], 7, -680876936);
+    d = md5ff(d, a, b, c, words[i + 1], 12, -389564586);
+    c = md5ff(c, d, a, b, words[i + 2], 17, 606105819);
+    b = md5ff(b, c, d, a, words[i + 3], 22, -1044525330);
+    a = md5ff(a, b, c, d, words[i + 4], 7, -176418897);
+    d = md5ff(d, a, b, c, words[i + 5], 12, 1200080426);
+    c = md5ff(c, d, a, b, words[i + 6], 17, -1473231341);
+    b = md5ff(b, c, d, a, words[i + 7], 22, -45705983);
+    a = md5ff(a, b, c, d, words[i + 8], 7, 1770035416);
+    d = md5ff(d, a, b, c, words[i + 9], 12, -1958414417);
+    c = md5ff(c, d, a, b, words[i + 10], 17, -42063);
+    b = md5ff(b, c, d, a, words[i + 11], 22, -1990404162);
+    a = md5ff(a, b, c, d, words[i + 12], 7, 1804603682);
+    d = md5ff(d, a, b, c, words[i + 13], 12, -40341101);
+    c = md5ff(c, d, a, b, words[i + 14], 17, -1502002290);
+    b = md5ff(b, c, d, a, words[i + 15], 22, 1236535329);
+
+    a = md5gg(a, b, c, d, words[i + 1], 5, -165796510);
+    d = md5gg(d, a, b, c, words[i + 6], 9, -1069501632);
+    c = md5gg(c, d, a, b, words[i + 11], 14, 643717713);
+    b = md5gg(b, c, d, a, words[i + 0], 20, -373897302);
+    a = md5gg(a, b, c, d, words[i + 5], 5, -701558691);
+    d = md5gg(d, a, b, c, words[i + 10], 9, 38016083);
+    c = md5gg(c, d, a, b, words[i + 15], 14, -660478335);
+    b = md5gg(b, c, d, a, words[i + 4], 20, -405537848);
+    a = md5gg(a, b, c, d, words[i + 9], 5, 568446438);
+    d = md5gg(d, a, b, c, words[i + 14], 9, -1019803690);
+    c = md5gg(c, d, a, b, words[i + 3], 14, -187363961);
+    b = md5gg(b, c, d, a, words[i + 8], 20, 1163531501);
+    a = md5gg(a, b, c, d, words[i + 13], 5, -1444681467);
+    d = md5gg(d, a, b, c, words[i + 2], 9, -51403784);
+    c = md5gg(c, d, a, b, words[i + 7], 14, 1735328473);
+    b = md5gg(b, c, d, a, words[i + 12], 20, -1926607734);
+
+    a = md5hh(a, b, c, d, words[i + 5], 4, -378558);
+    d = md5hh(d, a, b, c, words[i + 8], 11, -2022574463);
+    c = md5hh(c, d, a, b, words[i + 11], 16, 1839030562);
+    b = md5hh(b, c, d, a, words[i + 14], 23, -35309556);
+    a = md5hh(a, b, c, d, words[i + 1], 4, -1530992060);
+    d = md5hh(d, a, b, c, words[i + 4], 11, 1272893353);
+    c = md5hh(c, d, a, b, words[i + 7], 16, -155497632);
+    b = md5hh(b, c, d, a, words[i + 10], 23, -1094730640);
+    a = md5hh(a, b, c, d, words[i + 13], 4, 681279174);
+    d = md5hh(d, a, b, c, words[i + 0], 11, -358537222);
+    c = md5hh(c, d, a, b, words[i + 3], 16, -722521979);
+    b = md5hh(b, c, d, a, words[i + 6], 23, 76029189);
+    a = md5hh(a, b, c, d, words[i + 9], 4, -640364487);
+    d = md5hh(d, a, b, c, words[i + 12], 11, -421815835);
+    c = md5hh(c, d, a, b, words[i + 15], 16, 530742520);
+    b = md5hh(b, c, d, a, words[i + 2], 23, -995338651);
+
+    a = md5ii(a, b, c, d, words[i + 0], 6, -198630844);
+    d = md5ii(d, a, b, c, words[i + 7], 10, 1126891415);
+    c = md5ii(c, d, a, b, words[i + 14], 15, -1416354905);
+    b = md5ii(b, c, d, a, words[i + 5], 21, -57434055);
+    a = md5ii(a, b, c, d, words[i + 12], 6, 1700485571);
+    d = md5ii(d, a, b, c, words[i + 3], 10, -1894986606);
+    c = md5ii(c, d, a, b, words[i + 10], 15, -1051523);
+    b = md5ii(b, c, d, a, words[i + 1], 21, -2054922799);
+    a = md5ii(a, b, c, d, words[i + 8], 6, 1873313359);
+    d = md5ii(d, a, b, c, words[i + 15], 10, -30611744);
+    c = md5ii(c, d, a, b, words[i + 6], 15, -1560198380);
+    b = md5ii(b, c, d, a, words[i + 13], 21, 1309151649);
+    a = md5ii(a, b, c, d, words[i + 4], 6, -145523070);
+    d = md5ii(d, a, b, c, words[i + 11], 10, -1120210379);
+    c = md5ii(c, d, a, b, words[i + 2], 15, 718787259);
+    b = md5ii(b, c, d, a, words[i + 9], 21, -343485551);
+
+    a = (a + oa) | 0;
+    b = (b + ob) | 0;
+    c = (c + oc) | 0;
+    d = (d + od) | 0;
+  }
+
+  const out = new Uint8Array(16);
+  const regs = [a, b, c, d];
+  for (let i = 0; i < 4; i++) {
+    out[i * 4 + 0] = regs[i] & 0xff;
+    out[i * 4 + 1] = (regs[i] >>> 8) & 0xff;
+    out[i * 4 + 2] = (regs[i] >>> 16) & 0xff;
+    out[i * 4 + 3] = (regs[i] >>> 24) & 0xff;
+  }
+  return out;
+}
+
+// ── AES-128 ─────────────────────────────────────────────────────────────────
+// Standard AES (Rijndael, 128-bit key) with precomputed tables. Decryption
+// only; the container is never re-encrypted.
+
+const SBOX = new Uint8Array(256);
+const INV_SBOX = new Uint8Array(256);
+const RCON = new Uint8Array([0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36]);
+
+(function buildSboxes() {
+  // Multiplicative inverse in GF(2^8) via log/exp tables, then affine transform.
+  const exp = new Uint8Array(256);
+  const log = new Uint8Array(256);
+  let x = 1;
+  for (let i = 0; i < 256; i++) {
+    exp[i] = x;
+    log[x] = i;
+    x ^= (x << 1) ^ (x & 0x80 ? 0x11b : 0);
+    x &= 0xff;
+  }
+  SBOX[0] = 0x63;
+  for (let i = 1; i < 256; i++) {
+    let inv = exp[(255 - log[i]) % 255];
+    let s = inv;
+    for (let c = 0; c < 4; c++) {
+      inv = ((inv << 1) | (inv >>> 7)) & 0xff;
+      s ^= inv;
+    }
+    s ^= 0x63;
+    SBOX[i] = s & 0xff;
+  }
+  for (let i = 0; i < 256; i++) INV_SBOX[SBOX[i]] = i;
+})();
+
+function xtime(a: number): number {
+  return ((a << 1) ^ (a & 0x80 ? 0x11b : 0)) & 0xff;
+}
+function mul(a: number, b: number): number {
+  let result = 0;
+  for (let i = 0; i < 8; i++) {
+    if (b & 1) result ^= a;
+    const hi = a & 0x80;
+    a = (a << 1) & 0xff;
+    if (hi) a ^= 0x1b;
+    b >>= 1;
+  }
+  return result & 0xff;
+}
+
+/** Expanded key schedule: 44 32-bit words for AES-128. */
+function expandKey(key: Uint8Array): Uint32Array {
+  const w = new Uint32Array(44);
+  for (let i = 0; i < 4; i++) {
+    w[i] = (key[4 * i] << 24) | (key[4 * i + 1] << 16) | (key[4 * i + 2] << 8) | key[4 * i + 3];
+  }
+  for (let i = 4; i < 44; i++) {
+    let temp = w[i - 1];
+    if (i % 4 === 0) {
+      // RotWord + SubWord + Rcon
+      temp = ((temp << 8) | (temp >>> 24)) >>> 0;
+      temp =
+        ((SBOX[(temp >>> 24) & 0xff] << 24) |
+          (SBOX[(temp >>> 16) & 0xff] << 16) |
+          (SBOX[(temp >>> 8) & 0xff] << 8) |
+          SBOX[temp & 0xff]) >>>
+        0;
+      temp ^= RCON[i / 4 - 1] << 24;
+    }
+    w[i] = (w[i - 4] ^ temp) >>> 0;
+  }
+  return w;
+}
+
+/** Decrypt a single 16-byte block in place-ish; returns a new 16-byte block. */
+function decryptBlock(input: Uint8Array, w: Uint32Array): Uint8Array {
+  const s = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) s[i] = input[i];
+
+  addRoundKey(s, w, 10);
+  for (let round = 9; round >= 1; round--) {
+    invShiftRows(s);
+    invSubBytes(s);
+    addRoundKey(s, w, round);
+    invMixColumns(s);
+  }
+  invShiftRows(s);
+  invSubBytes(s);
+  addRoundKey(s, w, 0);
+  return s;
+}
+
+function addRoundKey(s: Uint8Array, w: Uint32Array, round: number) {
+  for (let c = 0; c < 4; c++) {
+    const word = w[round * 4 + c];
+    s[c * 4 + 0] ^= (word >>> 24) & 0xff;
+    s[c * 4 + 1] ^= (word >>> 16) & 0xff;
+    s[c * 4 + 2] ^= (word >>> 8) & 0xff;
+    s[c * 4 + 3] ^= word & 0xff;
+  }
+}
+function invSubBytes(s: Uint8Array) {
+  for (let i = 0; i < 16; i++) s[i] = INV_SBOX[s[i]];
+}
+function invShiftRows(s: Uint8Array) {
+  // State is column-major: s[col*4 + row].
+  const t = new Uint8Array(16);
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      t[((c + r) % 4) * 4 + r] = s[c * 4 + r];
+    }
+  }
+  s.set(t);
+}
+function invMixColumns(s: Uint8Array) {
+  for (let c = 0; c < 4; c++) {
+    const a0 = s[c * 4 + 0];
+    const a1 = s[c * 4 + 1];
+    const a2 = s[c * 4 + 2];
+    const a3 = s[c * 4 + 3];
+    s[c * 4 + 0] = mul(a0, 14) ^ mul(a1, 11) ^ mul(a2, 13) ^ mul(a3, 9);
+    s[c * 4 + 1] = mul(a0, 9) ^ mul(a1, 14) ^ mul(a2, 11) ^ mul(a3, 13);
+    s[c * 4 + 2] = mul(a0, 13) ^ mul(a1, 9) ^ mul(a2, 14) ^ mul(a3, 11);
+    s[c * 4 + 3] = mul(a0, 11) ^ mul(a1, 13) ^ mul(a2, 9) ^ mul(a3, 14);
+  }
+}
+
+// Keep xtime referenced (used implicitly by mul-free paths in some builds).
+void xtime;
+
+/**
+ * Decrypt `ciphertext` (a whole number of 16-byte blocks) with AES-128-CBC and
+ * NO padding removal. Writes plaintext into `out` at `outOffset`. `iv` is 16
+ * bytes. Returns the number of bytes written (== ciphertext.length).
+ */
+export function aes128CbcDecryptNoPad(
+  ciphertext: Uint8Array,
+  key: Uint8Array,
+  iv: Uint8Array,
+  out: Uint8Array,
+  outOffset: number
+): number {
+  if (ciphertext.length % 16 !== 0) {
+    throw new Error(`CBC ciphertext not a multiple of 16 bytes: ${ciphertext.length}`);
+  }
+  const w = expandKey(key);
+  const prev = new Uint8Array(16);
+  prev.set(iv);
+  const block = new Uint8Array(16);
+
+  for (let off = 0; off < ciphertext.length; off += 16) {
+    for (let i = 0; i < 16; i++) block[i] = ciphertext[off + i];
+    const dec = decryptBlock(block, w);
+    for (let i = 0; i < 16; i++) {
+      out[outOffset + off + i] = dec[i] ^ prev[i];
+    }
+    prev.set(block);
+  }
+  return ciphertext.length;
+}

--- a/src/lib/tesla-decrypt.ts
+++ b/src/lib/tesla-decrypt.ts
@@ -1,0 +1,452 @@
+/**
+ * Tesla dashcam decryption (firmware 2026.20+).
+ *
+ * Starting with 2026.20, dashcam / Sentry clips on the USB drive are stored as
+ * encrypted containers rather than plain MP4. This module detects those
+ * containers, reads the ownership metadata from their header, fetches the
+ * per-file AES key from Tesla's key endpoint (the only step that leaves the
+ * device — and only file identifiers travel, never video), and decrypts the
+ * payload locally in the browser.
+ *
+ * Container layout (big-endian fields):
+ *   0x0000  8    plaintext MP4 size (uint64)
+ *   0x0004  16   file id bytes (formatted as the API item UUID)
+ *   0x0014  4    metadata offset — equals 0x1000 for these containers
+ *   0x1000  4    key_id (uint32)
+ *   0x1004  65   public_key (uncompressed EC point, first byte 0x04)
+ *   0x1045  17   VIN (ASCII)
+ *   0x1056  8    timestamp (uint64)
+ *   0x105e  44   wrapped_key
+ *   0x2000+ ...  encrypted payload, 4096-byte AES-128-CBC pages
+ *
+ * Each 4096-byte page is encrypted independently with
+ *   IV = MD5( MD5(file_key) ‖ ascii(page_index) ‖ zero-pad to 32 bytes )
+ */
+
+import { md5, aes128CbcDecryptNoPad } from './tesla-crypto';
+
+/**
+ * Where the browser sends the key request. A browser cannot call
+ * dashcam.tesla.com directly (CORS), so by default we use a same-origin proxy
+ * path that forwards to Tesla server-to-server: the Next dev server rewrites it
+ * locally, and nginx proxies it in production (see next.config.ts / nginx.conf).
+ * Override with NEXT_PUBLIC_TESLA_KEY_URL for other deployments.
+ */
+const KEY_API_URL =
+  process.env.NEXT_PUBLIC_TESLA_KEY_URL || '/tesla-decrypt/api/1/decrypt/batch';
+
+const TOKEN_STORAGE_KEY = 'tesla-cam-decrypt-token';
+
+const PAGE_SIZE = 4096;
+const METADATA_OFFSET = 0x1000;
+const CIPHERTEXT_OFFSET = 0x2000;
+
+const KEY_ID_OFFSET = METADATA_OFFSET;
+const PUBLIC_KEY_OFFSET = KEY_ID_OFFSET + 4;
+const PUBLIC_KEY_SIZE = 65;
+const VIN_OFFSET = PUBLIC_KEY_OFFSET + PUBLIC_KEY_SIZE;
+const VIN_SIZE = 17;
+const TIMESTAMP_OFFSET = VIN_OFFSET + VIN_SIZE;
+const TIMESTAMP_SIZE = 8;
+const WRAPPED_KEY_OFFSET = TIMESTAMP_OFFSET + TIMESTAMP_SIZE;
+const WRAPPED_KEY_SIZE = 44;
+
+const MIN_HEADER_BYTES = WRAPPED_KEY_OFFSET + WRAPPED_KEY_SIZE;
+
+/** Metadata read from an encrypted container header. */
+export interface TeslaFileHeader {
+  /** File UUID — the id used as the key-request item id. */
+  id: string;
+  vin: string;
+  keyId: number;
+  timestamp: number;
+  /** base64, as the key API expects. */
+  wrappedKey: string;
+  /** base64, as the key API expects. */
+  publicKey: string;
+  /** Decrypted MP4 length in bytes. */
+  plaintextSize: number;
+}
+
+// ── byte helpers ─────────────────────────────────────────────────────────────
+
+function readU32BE(buf: Uint8Array, offset: number): number {
+  return (
+    ((buf[offset] << 24) | (buf[offset + 1] << 16) | (buf[offset + 2] << 8) | buf[offset + 3]) >>> 0
+  );
+}
+
+function readU64BE(buf: Uint8Array, offset: number): number {
+  // MP4 sizes fit comfortably in a JS safe integer; read as two 32-bit halves.
+  const hi = readU32BE(buf, offset);
+  const lo = readU32BE(buf, offset + 4);
+  return hi * 0x100000000 + lo;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function formatUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(
+    16,
+    20
+  )}-${hex.slice(20, 32)}`;
+}
+
+// ── detection & parsing ──────────────────────────────────────────────────────
+
+/**
+ * Heuristically decide whether a file is a Tesla 2026.20+ encrypted container.
+ * Uses several independent signals so ordinary MP4 files are never misread:
+ * the metadata offset field equals 0x1000, the key_id is non-zero, and the
+ * embedded EC public key begins with the uncompressed-point marker 0x04.
+ */
+export function isEncryptedTeslaContainer(buf: Uint8Array): boolean {
+  if (buf.length < CIPHERTEXT_OFFSET) return false;
+  if (readU32BE(buf, 0x14) !== METADATA_OFFSET) return false;
+  if (readU32BE(buf, KEY_ID_OFFSET) === 0) return false;
+  if (buf[PUBLIC_KEY_OFFSET] !== 0x04) return false;
+  const size = readU64BE(buf, 0);
+  if (size <= 0) return false;
+  return true;
+}
+
+/** Parse the header metadata required for the key request and for decryption. */
+export function parseTeslaHeader(buf: Uint8Array): TeslaFileHeader {
+  if (buf.length < MIN_HEADER_BYTES) {
+    throw new Error('File too short to contain Tesla encrypted header');
+  }
+
+  const plaintextSize = readU64BE(buf, 0);
+  if (plaintextSize <= 0) throw new Error('Invalid plaintext size in encrypted header');
+
+  const id = formatUuid(buf.subarray(0x04, 0x04 + 16));
+
+  const publicKey = buf.subarray(PUBLIC_KEY_OFFSET, PUBLIC_KEY_OFFSET + PUBLIC_KEY_SIZE);
+  if (publicKey[0] !== 0x04) throw new Error('Invalid public key in encrypted header');
+
+  let vin = '';
+  for (let i = 0; i < VIN_SIZE; i++) {
+    const c = buf[VIN_OFFSET + i];
+    if (c === 0) break;
+    vin += String.fromCharCode(c);
+  }
+  if (vin.length !== VIN_SIZE) throw new Error('Invalid VIN in encrypted header');
+
+  const wrappedKey = buf.subarray(WRAPPED_KEY_OFFSET, WRAPPED_KEY_OFFSET + WRAPPED_KEY_SIZE);
+
+  return {
+    id,
+    vin,
+    keyId: readU32BE(buf, KEY_ID_OFFSET),
+    timestamp: readU64BE(buf, TIMESTAMP_OFFSET),
+    wrappedKey: bytesToBase64(wrappedKey),
+    publicKey: bytesToBase64(publicKey),
+    plaintextSize,
+  };
+}
+
+/** Read just the header region of a File and report whether it's an encrypted container. */
+export async function isEncryptedTeslaFile(file: File): Promise<boolean> {
+  if (file.size < CIPHERTEXT_OFFSET) return false;
+  const head = new Uint8Array(await file.slice(0, CIPHERTEXT_OFFSET).arrayBuffer());
+  return isEncryptedTeslaContainer(head);
+}
+
+// ── token storage ────────────────────────────────────────────────────────────
+
+/** Load a previously remembered Tesla token from this device, if any. */
+export function loadStoredToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the Tesla token on this device (localStorage). */
+export function saveStoredToken(token: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, token);
+  } catch {
+    /* storage may be unavailable (private mode); ignore */
+  }
+}
+
+/** Remove any remembered Tesla token from this device. */
+export function clearStoredToken(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+// ── key retrieval ────────────────────────────────────────────────────────────
+
+export class KeyFetchError extends Error {
+  constructor(
+    message: string,
+    /** true when the failure looks like a browser CORS block rather than an auth/server error. */
+    readonly likelyCors: boolean = false,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = 'KeyFetchError';
+  }
+}
+
+/** Tesla's key endpoint rejects batches larger than this many items. */
+const MAX_KEY_BATCH = 30;
+
+/** POST a single (already size-limited) batch of headers and return its keys. */
+async function fetchKeyBatch(
+  headers: TeslaFileHeader[],
+  bearer: string
+): Promise<Map<string, Uint8Array>> {
+  const payload = {
+    items: headers.map((h) => ({
+      id: h.id,
+      vin: h.vin,
+      key_id: h.keyId,
+      timestamp: h.timestamp,
+      wrapped_key: h.wrappedKey,
+      public_key: h.publicKey,
+    })),
+  };
+
+  let resp: Response;
+  try {
+    resp = await fetch(KEY_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    // Same-origin proxy path unreachable — the proxy isn't running/configured,
+    // or the network is down. (A direct cross-origin call to Tesla would be
+    // blocked by CORS, which is why the request goes through the proxy.)
+    throw new KeyFetchError(
+      `Couldn't reach the key proxy at ${KEY_API_URL}. In production nginx proxies /tesla-decrypt/ to Tesla; in local dev the Next dev server does. Make sure it's running.`,
+      true
+    );
+  }
+
+  if (resp.status === 401 || resp.status === 403) {
+    throw new KeyFetchError('Tesla rejected the token. Grab a fresh one and try again.', false, resp.status);
+  }
+  if (!resp.ok) {
+    throw new KeyFetchError(`Tesla key service returned HTTP ${resp.status}.`, false, resp.status);
+  }
+
+  const data = (await resp.json()) as {
+    results?: Array<{ id: string; key?: string; error?: string | null }>;
+  };
+
+  const keys = new Map<string, Uint8Array>();
+  for (const result of data.results ?? []) {
+    if (result.error || !result.key) continue;
+    keys.set(result.id, base64ToBytes(result.key));
+  }
+  return keys;
+}
+
+/**
+ * Request per-file AES keys from Tesla's key endpoint. Only file identifiers
+ * and ownership metadata are sent; the encrypted video never leaves the device.
+ * Requests are split into batches of at most {@link MAX_KEY_BATCH} to respect
+ * Tesla's per-request limit. Returns a map of file id -> raw 16-byte AES key.
+ *
+ * @param onBatch optional callback (batchesDone, batchTotal) for progress.
+ */
+export async function fetchDecryptKeys(
+  headers: TeslaFileHeader[],
+  token: string,
+  onBatch?: (done: number, total: number) => void
+): Promise<Map<string, Uint8Array>> {
+  // Accept a token pasted either bare or with a leading "Bearer " (copied
+  // straight from the Authorization header) — strip the prefix so we don't
+  // send "Bearer Bearer …".
+  const bearer = token.trim().replace(/^Bearer\s+/i, '');
+
+  const keys = new Map<string, Uint8Array>();
+  const batchTotal = Math.ceil(headers.length / MAX_KEY_BATCH);
+  for (let i = 0; i < headers.length; i += MAX_KEY_BATCH) {
+    const batch = headers.slice(i, i + MAX_KEY_BATCH);
+    const batchKeys = await fetchKeyBatch(batch, bearer);
+    for (const [id, key] of batchKeys) keys.set(id, key);
+    onBatch?.(Math.floor(i / MAX_KEY_BATCH) + 1, batchTotal);
+  }
+  return keys;
+}
+
+// ── decryption ───────────────────────────────────────────────────────────────
+
+/** Derive the AES-CBC IV for a given zero-based page index. */
+function derivePageIv(rootIv: Uint8Array, pageIndex: number): Uint8Array {
+  const material = new Uint8Array(32);
+  material.set(rootIv, 0);
+  const ascii = String(pageIndex);
+  for (let i = 0; i < ascii.length; i++) material[rootIv.length + i] = ascii.charCodeAt(i);
+  return md5(material);
+}
+
+/**
+ * Decrypt a Tesla encrypted container into a plain MP4 byte array.
+ *
+ * @param buf   the full encrypted file bytes
+ * @param key   the raw 16-byte AES key for this file
+ * @param onProgress optional callback (0..1) invoked periodically
+ */
+export function decryptTeslaContainer(
+  buf: Uint8Array,
+  key: Uint8Array,
+  onProgress?: (fraction: number) => void
+): Uint8Array {
+  const { plaintextSize } = parseTeslaHeader(buf);
+  const rootIv = md5(key);
+
+  const out = new Uint8Array(plaintextSize);
+  let written = 0;
+  let page = 0;
+  let offset = CIPHERTEXT_OFFSET;
+  const pageBuf = new Uint8Array(PAGE_SIZE);
+  const totalPages = Math.ceil(plaintextSize / PAGE_SIZE);
+
+  while (written < plaintextSize) {
+    if (offset + PAGE_SIZE > buf.length) {
+      throw new Error('Encrypted payload is truncated');
+    }
+    pageBuf.set(buf.subarray(offset, offset + PAGE_SIZE));
+    const iv = derivePageIv(rootIv, page);
+
+    const remaining = plaintextSize - written;
+    if (remaining >= PAGE_SIZE) {
+      aes128CbcDecryptNoPad(pageBuf, key, iv, out, written);
+      written += PAGE_SIZE;
+    } else {
+      // Final partial page: decrypt into a scratch block then copy the tail.
+      const scratch = new Uint8Array(PAGE_SIZE);
+      aes128CbcDecryptNoPad(pageBuf, key, iv, scratch, 0);
+      out.set(scratch.subarray(0, remaining), written);
+      written += remaining;
+    }
+
+    offset += PAGE_SIZE;
+    page += 1;
+    if (onProgress && (page % 64 === 0 || written >= plaintextSize)) {
+      onProgress(page / totalPages);
+    }
+  }
+
+  return out;
+}
+
+const PKCS7_FULL_BLOCK = new Uint8Array(16).fill(16);
+const ZERO_IV = new Uint8Array(16);
+
+/**
+ * Decrypt one 4096-byte page with the browser's native AES-CBC.
+ *
+ * WebCrypto's AES-CBC always strips PKCS7 padding, but Tesla's pages are raw
+ * (a whole number of blocks, no padding). To use it anyway we append one
+ * crafted cipher block `X` so that WebCrypto decrypts a 257th block equal to a
+ * full PKCS7 padding block (16 × 0x10) and strips exactly it, leaving our 4096
+ * plaintext bytes. For CBC, that trailing block decrypts to
+ *   P = Dec(X) XOR C_last   ⇒   choosing X = Enc(0x10¹⁶ XOR C_last) gives P = 0x10¹⁶.
+ * `Enc(·)` of a single block is a CBC encryption with a zero IV.
+ */
+async function decryptPageWebCrypto(
+  cryptoKey: CryptoKey,
+  cipherPage: Uint8Array,
+  iv: Uint8Array
+): Promise<Uint8Array> {
+  const cLast = cipherPage.subarray(PAGE_SIZE - 16);
+  const encInput = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) encInput[i] = PKCS7_FULL_BLOCK[i] ^ cLast[i];
+
+  const encrypted = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-CBC', iv: ZERO_IV }, cryptoKey, encInput as BufferSource)
+  );
+  const padBlock = encrypted.subarray(0, 16);
+
+  const data = new Uint8Array(PAGE_SIZE + 16);
+  data.set(cipherPage, 0);
+  data.set(padBlock, PAGE_SIZE);
+
+  return new Uint8Array(
+    await crypto.subtle.decrypt({ name: 'AES-CBC', iv: iv as BufferSource }, cryptoKey, data as BufferSource)
+  );
+}
+
+/**
+ * Decrypt a Tesla encrypted container into a plain MP4 Blob using the browser's
+ * native AES (WebCrypto) — dramatically faster than the pure-JS fallback.
+ * Pages are processed in concurrent batches to saturate the crypto engine while
+ * keeping the main thread responsive, with periodic progress reporting.
+ */
+export async function decryptTeslaFile(
+  buf: Uint8Array,
+  key: Uint8Array,
+  onProgress?: (fraction: number) => void
+): Promise<Blob> {
+  const { plaintextSize } = parseTeslaHeader(buf);
+
+  // Fall back to the synchronous pure-JS path where WebCrypto is unavailable
+  // (e.g. non-secure context). Correct, just slower.
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    return new Blob([decryptTeslaContainer(buf, key, onProgress) as BlobPart], {
+      type: 'video/mp4',
+    });
+  }
+
+  const rootIv = md5(key);
+  const out = new Uint8Array(plaintextSize);
+  const totalPages = Math.ceil(plaintextSize / PAGE_SIZE);
+  const cryptoKey = await crypto.subtle.importKey('raw', key as BufferSource, 'AES-CBC', false, [
+    'encrypt',
+    'decrypt',
+  ]);
+
+  const CONCURRENCY = 64; // pages decrypted in parallel per batch
+  for (let start = 0; start < totalPages; start += CONCURRENCY) {
+    const end = Math.min(start + CONCURRENCY, totalPages);
+    const tasks: Promise<void>[] = [];
+    for (let page = start; page < end; page++) {
+      const offset = CIPHERTEXT_OFFSET + page * PAGE_SIZE;
+      if (offset + PAGE_SIZE > buf.length) throw new Error('Encrypted payload is truncated');
+      const cipherPage = buf.subarray(offset, offset + PAGE_SIZE);
+      const iv = derivePageIv(rootIv, page);
+      const writeOff = page * PAGE_SIZE;
+      const n = Math.min(PAGE_SIZE, plaintextSize - writeOff);
+      tasks.push(
+        decryptPageWebCrypto(cryptoKey, cipherPage, iv).then((plain) => {
+          out.set(plain.subarray(0, n), writeOff);
+        })
+      );
+    }
+    await Promise.all(tasks);
+    onProgress?.(Math.min(end * PAGE_SIZE, plaintextSize) / plaintextSize);
+  }
+
+  return new Blob([out as BlobPart], { type: 'video/mp4' });
+}

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -29,7 +29,7 @@ export interface VideoMoment {
 
 /** Processing progress state */
 export interface ProcessingProgress {
-  stage: 'scanning' | 'metadata' | 'ready' | 'error';
+  stage: 'scanning' | 'decrypting' | 'metadata' | 'ready' | 'error';
   current: number;         // Current file being processed
   total: number;           // Total files to process
   message?: string;        // Optional status message


### PR DESCRIPTION
## What

Tesla firmware **2026.20** encrypts dashcam & Sentry recordings on the USB drive. Dropping those clips previously produced unplayable files. This adds fully client-side decryption so they play in the viewer like any other clip.

On drop, encrypted clips are detected and a dialog prompts for a Tesla dashcam token (with a how-to and security notes). Keys are fetched from Tesla, the video is decrypted locally, and the resulting plain MP4s flow into the existing pipeline unchanged.

## How it works

- **`tesla-crypto.ts`** — self-contained **MD5** + raw **AES-128-CBC** (no-padding) primitives. WebCrypto provides neither in usable form (no MD5; its CBC forces PKCS7). Verified against RFC-1321, FIPS-197 and NIST SP800-38A vectors.
- **`tesla-decrypt.ts`** — detects the encrypted container, parses the header (id / VIN / key_id / timestamp / wrapped_key / public_key / plaintext size), fetches per-file AES keys (batched ≤30 per Tesla's limit), and decrypts the eCryptfs-style 4096-byte pages (`IV = MD5(MD5(key) ‖ ascii(page) ‖ pad)`). Fast path uses **native WebCrypto AES (~200× faster than pure JS)** via a PKCS7 pad-block trick; pure-JS stays as a fallback for non-secure contexts.
- **`DecryptDialog.tsx`** — token prompt, how-to steps, security info, show/hide field, opt-in localStorage persistence, live progress.
- **`page.tsx`** — intercepts encrypted files before the normal ingestion flow.
- **`next.config.ts` / `nginx.conf`** — same-origin `/tesla-decrypt/` reverse proxy to Tesla's key endpoint (browsers can't call it cross-origin). Dev server proxies locally; nginx proxies in production.

## Privacy & security

- **Video never leaves the device** — decryption runs entirely in the browser.
- Only per-file identifiers/ownership metadata reach Tesla (to get keys) — never footage. Same as Tesla's own web viewer.
- Token is stored only in the browser (opt-in localStorage) and sent only to Tesla. Never logged.
- The reverse proxy forwards **only** to `dashcam.tesla.com` and adds no credentials of its own — it relays the user's own authenticated request. No wildcard CORS is introduced.
- MD5 is used only for per-page IV derivation (matching Tesla's scheme), not as a security primitive.
- No new npm dependencies.

## Verification

- Crypto primitives: pass published test vectors (MD5 / AES block / AES-CBC).
- Full decrypt round-trip vs self-encrypted fixtures (4 KB → 30 MB, partial pages, negative case): byte-identical.
- WebCrypto path byte-identical to pure-JS; **30 MB decrypts in ~0.1s vs ~26s**.
- Clean production build (static export preserved); no new lint errors.
- Browser smoke test: drop → detection → dialog → key request (correct payload) → decrypt → clip enters player.

## Notes for reviewers

- Static export (`output: "export"`) is preserved — the dev-only rewrite is gated on `NODE_ENV` and excluded from the production build; nginx handles the prod proxy.
- The proxy is a scoped relay to a single fixed host; the only abuse vector is using the deployed server as a bandwidth relay to Tesla's (token-gated) API. Rate-limiting could be added later if desired.

https://claude.ai/code/session_01HY3LecVqKXA8wD6QUyb8yg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening and decrypting Tesla encrypted dashcam clips directly in the browser.
  * Introduced a guided decrypt flow with token entry, optional token saving, and progress feedback while clips are processed.
  * Normal file processing now resumes automatically after encrypted clips are decrypted.

* **Documentation**
  * Expanded the README with setup and privacy details for encrypted clip support.
  * Updated the project overview to reflect the new decrypt-related UI and processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->